### PR TITLE
fix: update Firefox manifest for Mozilla data collection requirements

### DIFF
--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -70,9 +70,9 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "order-history-exporter@amazon.example",
-      "strict_min_version": "109.0",
+      "strict_min_version": "140.0",
       "data_collection_permissions": {
-        "required": false
+        "required": []
       }
     }
   }


### PR DESCRIPTION
- Change data_collection_permissions.required from boolean to empty array

- Update strict_min_version to 140.0 (required for data_collection_permissions support)