### PR TITLE
fix: correct Firefox manifest data_collection_permissions format

### DIFF
--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -70,9 +70,9 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "order-history-exporter@amazon.example",
-      "strict_min_version": "140.0",
+      "strict_min_version": "142.0",
       "data_collection_permissions": {
-        "required": []
+        "required": ["none"]
       }
     }
   }


### PR DESCRIPTION
- Set required to ['none'] as empty array is not allowed

- Update strict_min_version to 142.0 for Firefox Android compatibility