### PR TITLE
chore(hooks): add Husky pre-commit checks for lint and formatting

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+npm run lint
+npm run format:check

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "esbuild": "0.27.2",
         "eslint": "9.39.2",
         "eslint-config-prettier": "^10.1.8",
+        "husky": "^9.1.7",
         "knip": "5.82.1",
         "prettier": "^3.8.1",
         "typescript": "5.9.3",
@@ -2719,6 +2720,22 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
     },
     "node_modules/ignore": {
       "version": "7.0.5",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "knip": "knip"
+    "knip": "knip",
+    "prepare": "husky"
   },
   "keywords": [
     "amazon",
@@ -41,6 +42,7 @@
     "esbuild": "0.27.2",
     "eslint": "9.39.2",
     "eslint-config-prettier": "^10.1.8",
+    "husky": "^9.1.7",
     "knip": "5.82.1",
     "prettier": "^3.8.1",
     "typescript": "5.9.3",


### PR DESCRIPTION
This pull request introduces Husky to the project to automate pre-commit checks and ensures code quality by running linting and formatting checks before commits. Additionally, it updates the `package.json` to include Husky as a development dependency and configures the prepare script for Husky installation.

Tooling and automation improvements:

* Added Husky as a development dependency in `package.json` and set up the `prepare` script to initialize Husky. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L23-R24) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R45)
* Created a `.husky/pre-commit` hook to automatically run `npm run lint` and `npm run format:check` before each commit, enforcing code quality standards.