### PR TITLE
chore(github): add issue forms and strengthen PR template conventions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,71 @@
+name: Bug report
+description: Report a reproducible problem or regression
+title: '[Bug]: '
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug report. Please include enough detail to reproduce the issue.
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Describe the bug and what you expected instead.
+      placeholder: A clear and concise description of the problem.
+    validations:
+      required: true
+  - type: textarea
+    id: repro_steps
+    attributes:
+      label: Steps to reproduce
+      description: Provide a minimal, reliable reproduction.
+      placeholder: |
+        1. Go to ...
+        2. Click ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: input
+    id: amazon_domain
+    attributes:
+      label: Amazon domain
+      description: Which Amazon site were you using?
+      placeholder: 'e.g. amazon.com, amazon.de, amazon.co.uk'
+    validations:
+      required: true
+  - type: dropdown
+    id: browser
+    attributes:
+      label: Browser
+      options:
+        - Firefox
+        - Chrome
+        - Edge
+        - Brave
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: extension_version
+    attributes:
+      label: Extension version
+      placeholder: 'e.g. 1.2.3'
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or screenshots
+      description: Paste errors from browser devtools console if available.
+      render: shell
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true
+        - label: I can reproduce this issue on the latest release.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions and support
+    url: https://github.com/xenolphthalein/order-history-exporter-for-amazon/discussions
+    about: Please use Discussions for questions, troubleshooting, and general help.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,44 @@
+name: Feature request
+description: Suggest an improvement or new capability
+title: '[Feature]: '
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion. Please describe the problem and expected outcome clearly.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem to solve
+      description: What pain point are you experiencing?
+      placeholder: A clear and concise description of the current limitation.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the behavior you want.
+      placeholder: What should change, and how should it work?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you considered.
+      placeholder: Optional
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Use cases, examples, links, or screenshots.
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,48 @@
+## Summary
+
+Describe the change and why it is needed.
+
+## Related Issue
+
+Closes #
+
+## Maintainer Collaboration
+
+- [ ] I enabled **Allow edits from maintainers** on this PR.
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor
+- [ ] Documentation update
+- [ ] Chore/maintenance
+
+## Breaking Changes
+
+- [ ] This PR introduces a breaking change.
+- [ ] I documented migration or compatibility notes (if applicable).
+
+## UI Changes
+
+- [ ] This PR includes UI changes.
+- [ ] I added screenshots or recordings for UI changes (if applicable).
+
+## How Was This Tested?
+
+List the commands and/or manual checks you ran.
+
+```bash
+npm run lint
+npm run typecheck
+npm run test
+npm run format:check
+```
+
+## Checklist
+
+- [ ] I verified the change locally.
+- [ ] I added or updated tests when behavior changed.
+- [ ] I updated documentation when needed.
+- [ ] I updated locale/messages or metadata when needed.
+- [ ] I confirmed no sensitive data was added.


### PR DESCRIPTION
- add bug report and feature request issue templates
- disable blank issues and route support questions to Discussions
- update PR template with maintainer-editability requirement
- add breaking-change and UI-change checklist conventions
- keep PR test checklist aligned with lint/typecheck/test/format checks