### PR TITLE
chore: bump version to 1.1.0 in package and manifest files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "order-history-exporter-for-amazon",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "order-history-exporter-for-amazon",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "webextension-polyfill": "0.12.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "order-history-exporter-for-amazon",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Export your Amazon order history as JSON or CSV files",
   "type": "module",
   "scripts": {

--- a/src/manifest.chrome.json
+++ b/src/manifest.chrome.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "__MSG_extensionDescription__",
   "default_locale": "en",
   "icons": {

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "__MSG_extensionDescription__",
   "default_locale": "en",
   "icons": {


### PR DESCRIPTION
This pull request updates the version number of the project from 1.0.0 to 1.1.0 across all relevant files to prepare for a new release. There are no other code or functional changes included.

- Version updates:
  * Bumped the version to 1.1.0 in `package.json`
  * Updated the version to 1.1.0 in `src/manifest.chrome.json`
  * Updated the version to 1.1.0 in `src/manifest.firefox.json`