### PR TITLE
feat(export): include card brand and last 4 digits in export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1623,6 +1623,7 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -1969,6 +1970,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2250,6 +2252,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2859,6 +2862,7 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -3672,6 +3676,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3685,8 +3690,7 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -3704,6 +3708,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -3779,6 +3784,7 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -218,5 +218,25 @@
   "csvHeaderDetailsUrl": {
     "message": "Details-Link",
     "description": "CSV header for details URL"
+  },
+  "extraData": {
+    "message": "Zusatzdaten",
+    "description": "Section title for optional extra data toggles"
+  },
+  "includePaymentMethod": {
+    "message": "Zahlungsmethode einbeziehen",
+    "description": "Checkbox to opt in to capturing card brand + last 4 digits"
+  },
+  "paymentMethodHint": {
+    "message": "Erfasst nur Kartenmarke und die letzten 4 Ziffern. Amazon zeigt nie die vollständige Kartennummer an.",
+    "description": "Hint clarifying what payment data is captured"
+  },
+  "csvHeaderCardBrand": {
+    "message": "Kartenmarke",
+    "description": "CSV header for card brand"
+  },
+  "csvHeaderCardLast4": {
+    "message": "Letzte 4 Ziffern",
+    "description": "CSV header for card last 4 digits"
   }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -218,5 +218,25 @@
   "csvHeaderDetailsUrl": {
     "message": "Details URL",
     "description": "CSV header for details URL"
+  },
+  "extraData": {
+    "message": "Extra Data",
+    "description": "Section title for optional extra data toggles"
+  },
+  "includePaymentMethod": {
+    "message": "Include payment method",
+    "description": "Checkbox to opt in to capturing card brand + last 4 digits"
+  },
+  "paymentMethodHint": {
+    "message": "Captures card brand and last 4 digits only. Amazon never exposes the full card number.",
+    "description": "Hint clarifying what payment data is captured"
+  },
+  "csvHeaderCardBrand": {
+    "message": "Card Brand",
+    "description": "CSV header for card brand"
+  },
+  "csvHeaderCardLast4": {
+    "message": "Card Last 4",
+    "description": "CSV header for card last 4 digits"
   }
 }

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -218,5 +218,25 @@
   "csvHeaderDetailsUrl": {
     "message": "URL de detalles",
     "description": "CSV header for details URL"
+  },
+  "extraData": {
+    "message": "Datos adicionales",
+    "description": "Section title for optional extra data toggles"
+  },
+  "includePaymentMethod": {
+    "message": "Incluir método de pago",
+    "description": "Checkbox to opt in to capturing card brand + last 4 digits"
+  },
+  "paymentMethodHint": {
+    "message": "Solo captura la marca de la tarjeta y los últimos 4 dígitos. Amazon nunca muestra el número completo.",
+    "description": "Hint clarifying what payment data is captured"
+  },
+  "csvHeaderCardBrand": {
+    "message": "Marca de tarjeta",
+    "description": "CSV header for card brand"
+  },
+  "csvHeaderCardLast4": {
+    "message": "Últimos 4 dígitos",
+    "description": "CSV header for card last 4 digits"
   }
 }

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -218,5 +218,25 @@
   "csvHeaderDetailsUrl": {
     "message": "URL des détails",
     "description": "CSV header for details URL"
+  },
+  "extraData": {
+    "message": "Données supplémentaires",
+    "description": "Section title for optional extra data toggles"
+  },
+  "includePaymentMethod": {
+    "message": "Inclure le moyen de paiement",
+    "description": "Checkbox to opt in to capturing card brand + last 4 digits"
+  },
+  "paymentMethodHint": {
+    "message": "Ne capture que la marque de la carte et les 4 derniers chiffres. Amazon n'expose jamais le numéro complet.",
+    "description": "Hint clarifying what payment data is captured"
+  },
+  "csvHeaderCardBrand": {
+    "message": "Marque de carte",
+    "description": "CSV header for card brand"
+  },
+  "csvHeaderCardLast4": {
+    "message": "4 derniers chiffres",
+    "description": "CSV header for card last 4 digits"
   }
 }

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -19,6 +19,7 @@ import {
   extractPriceFromText,
   parsePrice,
   parseOrderStatus,
+  parsePaymentMethodFromHtml,
 } from '../utils';
 
 (function (): void {
@@ -105,7 +106,7 @@ import {
    * Start a new export
    */
   function startExport(options: ExportOptions): void {
-    const { format, startDate, endDate, exportAll } = options;
+    const { format, startDate, endDate, exportAll, includePaymentMethod } = options;
 
     // Get available years
     const years = getAvailableYears();
@@ -130,6 +131,7 @@ import {
       startDate: startDate,
       endDate: endDate,
       exportAll: exportAll,
+      includePaymentMethod: includePaymentMethod,
       yearsToProcess: yearsToProcess,
       currentYearIndex: 0,
       currentStartIndex: 0,
@@ -244,7 +246,7 @@ import {
     updateProgress(80, getMessage('fetchingPrices', [String(state.collectedOrders.length)]));
 
     // Fetch item prices for multi-item orders
-    await fetchOrderDetailsForPrices(state.collectedOrders);
+    await fetchOrderDetailsForPrices(state.collectedOrders, state.includePaymentMethod);
 
     updateProgress(95, getMessage('generatingFile'));
 
@@ -259,7 +261,7 @@ import {
       fileName = `amazon-orders-${timestamp}.json`;
       mimeType = 'application/json';
     } else {
-      fileContent = convertToCSV(state.collectedOrders);
+      fileContent = convertToCSV(state.collectedOrders, state.includePaymentMethod);
       fileName = `amazon-orders-${timestamp}.csv`;
       mimeType = 'text/csv';
     }
@@ -657,7 +659,10 @@ import {
   /**
    * Fetch order details for item prices and discounts
    */
-  async function fetchOrderDetailsForPrices(orders: Order[]): Promise<void> {
+  async function fetchOrderDetailsForPrices(
+    orders: Order[],
+    includePaymentMethod: boolean
+  ): Promise<void> {
     // We need to fetch details for all orders to get accurate pricing and discounts
     // Even single-item orders can have discounts
     const ordersNeedingDetails = orders.filter((order) => order.detailsUrl);
@@ -686,6 +691,13 @@ import {
 
         parseItemPricesFromDetails(order, doc);
         parsePromotionsFromDetails(order, doc);
+
+        if (includePaymentMethod) {
+          const paymentMethod = parsePaymentMethodFromHtml(doc);
+          if (paymentMethod) {
+            order.paymentMethod = paymentMethod;
+          }
+        }
 
         await new Promise((resolve) => setTimeout(resolve, 200));
       } catch (error) {
@@ -904,8 +916,8 @@ import {
   /**
    * Convert orders to CSV format (wrapper using utility function)
    */
-  function convertToCSV(orders: Order[]): string {
-    return convertOrdersToCSV(orders, getMessage);
+  function convertToCSV(orders: Order[], includePaymentMethod: boolean): string {
+    return convertOrdersToCSV(orders, getMessage, { includePaymentMethod });
   }
 
   /**

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -70,6 +70,40 @@ header h1 {
   accent-color: #ff9900;
 }
 
+.checkbox-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  padding: 8px 12px;
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  transition: all 0.2s ease;
+}
+
+.checkbox-label:hover {
+  border-color: #ff9900;
+  background: #fff8e5;
+}
+
+.checkbox-label input[type='checkbox'] {
+  accent-color: #ff9900;
+}
+
+.hint {
+  font-size: 11px;
+  line-height: 1.4;
+  color: #777;
+  padding: 0 4px;
+}
+
 .date-inputs {
   margin-top: 12px;
   padding: 12px;

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -66,6 +66,19 @@
               </label>
             </div>
           </section>
+
+          <section class="section">
+            <h2 data-i18n="extraData">Extra Data</h2>
+            <div class="checkbox-group">
+              <label class="checkbox-label">
+                <input type="checkbox" id="includePaymentMethod" />
+                <span data-i18n="includePaymentMethod">Include payment method</span>
+              </label>
+              <p class="hint" data-i18n="paymentMethodHint">
+                Captures card brand and last 4 digits only. Amazon never exposes the full card number.
+              </p>
+            </div>
+          </section>
         </div>
 
         <section class="section">

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -45,6 +45,9 @@ document.addEventListener('DOMContentLoaded', async () => {
   const startDateInput = document.getElementById('startDate') as HTMLInputElement;
   const endDateInput = document.getElementById('endDate') as HTMLInputElement;
   const settingsSection = document.getElementById('settings-section') as HTMLElement;
+  const includePaymentMethodInput = document.getElementById(
+    'includePaymentMethod'
+  ) as HTMLInputElement;
 
   // Set default date values
   const today = new Date();
@@ -124,6 +127,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         startDate: startDate,
         endDate: endDate,
         exportAll: exportRange === 'all',
+        includePaymentMethod: includePaymentMethodInput?.checked === true,
       };
 
       // Send message to content script

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,6 +11,15 @@ export interface OrderItem {
   itemUrl: string;
 }
 
+// Amazon never exposes full card numbers (PCI-DSS). The most we can capture
+// is whatever the order details page renders to the logged-in user — typically
+// a card brand and the last 4 digits, e.g. "Visa ending in 1234".
+export interface PaymentMethod {
+  brand: string;
+  last4: string;
+  raw: string;
+}
+
 export interface Order {
   orderId: string;
   orderDate: string;
@@ -21,6 +30,7 @@ export interface Order {
   detailsUrl: string;
   promotions: Promotion[];
   totalSavings: number;
+  paymentMethod?: PaymentMethod;
 }
 
 export interface Promotion {
@@ -33,6 +43,7 @@ export interface ExportOptions {
   startDate: string | null;
   endDate: string | null;
   exportAll: boolean;
+  includePaymentMethod: boolean;
 }
 
 export interface ExportState {
@@ -41,6 +52,7 @@ export interface ExportState {
   startDate: string | null;
   endDate: string | null;
   exportAll: boolean;
+  includePaymentMethod: boolean;
   yearsToProcess: string[];
   currentYearIndex: number;
   currentStartIndex: number;

--- a/src/utils/csvUtils.ts
+++ b/src/utils/csvUtils.ts
@@ -26,15 +26,23 @@ export function formatPromotionsForCSV(
   return promotions.map((p) => `${p.description}: €${p.amount}`).join('; ');
 }
 
+export interface CsvOptions {
+  includePaymentMethod?: boolean;
+}
+
 /**
  * Convert orders to CSV format
  * @param orders - Array of orders to convert
  * @param getHeader - Function to get localized header name
+ * @param options - Optional flags controlling which columns appear
  */
 export function convertOrdersToCSV(
   orders: Order[],
-  getHeader: (key: string) => string = (key) => key
+  getHeader: (key: string) => string = (key) => key,
+  options: CsvOptions = {}
 ): string {
+  const { includePaymentMethod = false } = options;
+
   const headers = [
     getHeader('csvHeaderOrderId'),
     getHeader('csvHeaderOrderDate'),
@@ -52,10 +60,20 @@ export function convertOrdersToCSV(
     getHeader('csvHeaderDetailsUrl'),
   ];
 
+  if (includePaymentMethod) {
+    headers.push(getHeader('csvHeaderCardBrand'), getHeader('csvHeaderCardLast4'));
+  }
+
   const rows: string[] = [headers.join(',')];
 
   orders.forEach((order) => {
     const promotionsStr = formatPromotionsForCSV(order.promotions);
+    const paymentCols = includePaymentMethod
+      ? [
+          escapeCSVValue(order.paymentMethod?.brand ?? ''),
+          escapeCSVValue(order.paymentMethod?.last4 ?? ''),
+        ]
+      : [];
 
     if (order.items.length === 0) {
       rows.push(
@@ -74,6 +92,7 @@ export function convertOrdersToCSV(
           escapeCSVValue(promotionsStr),
           '',
           escapeCSVValue(order.detailsUrl),
+          ...paymentCols,
         ].join(',')
       );
     } else {
@@ -94,6 +113,7 @@ export function convertOrdersToCSV(
             index === 0 ? escapeCSVValue(promotionsStr) : '',
             escapeCSVValue(item.itemUrl),
             escapeCSVValue(order.detailsUrl),
+            ...(index === 0 ? paymentCols : paymentCols.map(() => '')),
           ].join(',')
         );
       });

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -8,3 +8,4 @@ export * from './orderUtils';
 export * from './statusUtils';
 export * from './csvUtils';
 export * from './urlUtils';
+export * from './paymentUtils';

--- a/src/utils/paymentUtils.ts
+++ b/src/utils/paymentUtils.ts
@@ -1,0 +1,111 @@
+/**
+ * Payment-method parsing utilities.
+ *
+ * Amazon never exposes full card numbers (PCI-DSS). This module only
+ * recognises what Amazon actually renders to the logged-in user on the
+ * order details page: a card brand and the last 4 digits, e.g.
+ * "Visa ending in 1234" / "Visa endet auf 1234" / "Visa se terminant par 1234".
+ */
+
+import type { PaymentMethod } from '../types';
+
+const KNOWN_BRANDS: { pattern: RegExp; canonical: string }[] = [
+  { pattern: /\bvisa\b/i, canonical: 'Visa' },
+  { pattern: /\bmaster\s*card\b/i, canonical: 'Mastercard' },
+  { pattern: /\bamerican\s+express\b/i, canonical: 'American Express' },
+  { pattern: /\bamex\b/i, canonical: 'American Express' },
+  { pattern: /\bdiscover\b/i, canonical: 'Discover' },
+  { pattern: /\bdiners\s*club\b/i, canonical: 'Diners Club' },
+  { pattern: /\bjcb\b/i, canonical: 'JCB' },
+  { pattern: /\bunionpay\b/i, canonical: 'UnionPay' },
+];
+
+// Phrases that immediately precede a 4-digit card suffix on the order
+// details page, by locale. Keep these loose; Amazon shifts copy between
+// experiments.
+const LAST4_PHRASES = [
+  // English
+  /(?:ending\s+(?:in|with)|ends?\s+with|ending)\s+(?:in\s+)?(\d{4})\b/i,
+  // German
+  /endet\s+auf\s+(\d{4})\b/i,
+  // French
+  /se\s+terminant\s+par\s+(\d{4})\b/i,
+  // Spanish
+  /(?:que\s+termina|termina|terminada)\s+en\s+(\d{4})\b/i,
+  // Generic masked forms: "**** 1234", "•••• 1234", "xxxx1234"
+  /(?:\*{2,}|•{2,}|x{2,})\s*[-\s]?\s*(\d{4})\b/i,
+];
+
+/**
+ * Extract a card brand from free text, if any known brand is mentioned.
+ */
+export function extractCardBrand(text: string): string {
+  for (const { pattern, canonical } of KNOWN_BRANDS) {
+    if (pattern.test(text)) return canonical;
+  }
+  return '';
+}
+
+/**
+ * Extract a card last-4 from free text, if a recognisable suffix phrase is present.
+ */
+export function extractCardLast4(text: string): string {
+  for (const pattern of LAST4_PHRASES) {
+    const match = text.match(pattern);
+    if (match?.[1]) return match[1];
+  }
+  return '';
+}
+
+/**
+ * Parse a payment method (brand + last 4) from a single block of text.
+ */
+export function parsePaymentMethodFromText(text: string): PaymentMethod | undefined {
+  const compact = text.replace(/\s+/g, ' ').trim();
+  if (!compact) return undefined;
+
+  const last4 = extractCardLast4(compact);
+  if (!last4) return undefined;
+
+  const brand = extractCardBrand(compact) || 'Card';
+
+  // Trim raw to a sensible length so it's safe in CSV.
+  const raw = compact.length > 120 ? compact.slice(0, 120) : compact;
+
+  return { brand, last4, raw };
+}
+
+/**
+ * Parse the payment method from a parsed order-details DOM.
+ *
+ * Strategy: walk a handful of candidate containers that Amazon has used for
+ * the "Payment Method" block across locales and templates. Return the first
+ * confident hit (brand + last4). If we only get last4 with no brand, that's
+ * still useful — surface it with brand="Card".
+ */
+export function parsePaymentMethodFromHtml(doc: Document): PaymentMethod | undefined {
+  const candidateSelectors = [
+    '#payment-information',
+    '#paymentInformation',
+    '[data-component="paymentMethod"]',
+    '[class*="payment-method"]',
+    '[class*="pmts-payment-instrument"]',
+    '.pmts-payment-instrument-detail-box',
+    '.a-box.payment-box',
+    '#od-subtotals',
+  ];
+
+  for (const selector of candidateSelectors) {
+    const containers = doc.querySelectorAll(selector);
+    for (const el of containers) {
+      const text = el.textContent || '';
+      const parsed = parsePaymentMethodFromText(text);
+      if (parsed) return parsed;
+    }
+  }
+
+  // Last-ditch: scan the whole body. This is more brittle but Amazon
+  // occasionally drops the canonical container, especially on legacy pages.
+  const bodyText = doc.body?.textContent || '';
+  return parsePaymentMethodFromText(bodyText);
+}

--- a/tests/csvUtils.test.ts
+++ b/tests/csvUtils.test.ts
@@ -176,4 +176,69 @@ describe('convertOrdersToCSV', () => {
     const csv = convertOrdersToCSV(orders);
     expect(csv).toContain('"Product ""with quotes"", and commas"');
   });
+
+  describe('payment method columns (opt-in)', () => {
+    it('does not add card columns by default', () => {
+      const orders = [createOrder({ paymentMethod: { brand: 'Visa', last4: '4242', raw: '' } })];
+      const csv = convertOrdersToCSV(orders);
+      expect(csv).not.toContain('csvHeaderCardBrand');
+      expect(csv).not.toContain('csvHeaderCardLast4');
+      expect(csv).not.toContain('Visa');
+      expect(csv).not.toContain('4242');
+    });
+
+    it('adds card columns when includePaymentMethod is true', () => {
+      const orders = [createOrder({ paymentMethod: { brand: 'Visa', last4: '4242', raw: '' } })];
+      const csv = convertOrdersToCSV(orders, undefined, { includePaymentMethod: true });
+      const lines = csv.split('\n');
+      expect(lines[0]).toContain('csvHeaderCardBrand');
+      expect(lines[0]).toContain('csvHeaderCardLast4');
+      expect(lines[1]).toContain('Visa');
+      expect(lines[1]).toContain('4242');
+    });
+
+    it('emits empty card columns when an order has no payment method captured', () => {
+      const orders = [createOrder()]; // no paymentMethod
+      const csv = convertOrdersToCSV(orders, undefined, { includePaymentMethod: true });
+      const lines = csv.split('\n');
+      const cols = lines[1]!.split(',');
+      // Last two columns are brand + last4 — both empty.
+      expect(cols[cols.length - 2]).toBe('');
+      expect(cols[cols.length - 1]).toBe('');
+    });
+
+    it('only emits payment info on the first item row of a multi-item order', () => {
+      const orders = [
+        createOrder({
+          paymentMethod: { brand: 'Visa', last4: '4242', raw: '' },
+          items: [
+            {
+              title: 'A',
+              asin: 'B000000001',
+              quantity: 1,
+              price: 1,
+              discount: 0,
+              itemUrl: 'https://amazon.de/dp/B000000001',
+            },
+            {
+              title: 'B',
+              asin: 'B000000002',
+              quantity: 1,
+              price: 1,
+              discount: 0,
+              itemUrl: 'https://amazon.de/dp/B000000002',
+            },
+          ],
+        }),
+      ];
+      const csv = convertOrdersToCSV(orders, undefined, { includePaymentMethod: true });
+      const lines = csv.split('\n');
+      const firstItemCols = lines[1]!.split(',');
+      const secondItemCols = lines[2]!.split(',');
+      expect(firstItemCols[firstItemCols.length - 2]).toBe('Visa');
+      expect(firstItemCols[firstItemCols.length - 1]).toBe('4242');
+      expect(secondItemCols[secondItemCols.length - 2]).toBe('');
+      expect(secondItemCols[secondItemCols.length - 1]).toBe('');
+    });
+  });
 });

--- a/tests/paymentUtils.test.ts
+++ b/tests/paymentUtils.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import {
+  extractCardBrand,
+  extractCardLast4,
+  parsePaymentMethodFromText,
+} from '../src/utils/paymentUtils';
+
+describe('extractCardBrand', () => {
+  it('detects Visa', () => {
+    expect(extractCardBrand('Visa ending in 1234')).toBe('Visa');
+  });
+
+  it('detects Mastercard with or without space', () => {
+    expect(extractCardBrand('Mastercard ending in 1234')).toBe('Mastercard');
+    expect(extractCardBrand('Master Card ending in 1234')).toBe('Mastercard');
+  });
+
+  it('detects American Express and Amex shorthand', () => {
+    expect(extractCardBrand('American Express ending in 1234')).toBe('American Express');
+    expect(extractCardBrand('Amex card 1234')).toBe('American Express');
+  });
+
+  it('returns empty string when no known brand is found', () => {
+    expect(extractCardBrand('PayPal balance')).toBe('');
+  });
+});
+
+describe('extractCardLast4', () => {
+  it('parses the English "ending in N" phrase', () => {
+    expect(extractCardLast4('Visa ending in 4242')).toBe('4242');
+  });
+
+  it('parses the German "endet auf N" phrase', () => {
+    expect(extractCardLast4('Visa endet auf 4242')).toBe('4242');
+  });
+
+  it('parses the French "se terminant par N" phrase', () => {
+    expect(extractCardLast4('Visa se terminant par 4242')).toBe('4242');
+  });
+
+  it('parses the Spanish "que termina en N" phrase', () => {
+    expect(extractCardLast4('Visa que termina en 4242')).toBe('4242');
+  });
+
+  it('parses masked forms like **** 1234', () => {
+    expect(extractCardLast4('Visa **** 4242')).toBe('4242');
+    expect(extractCardLast4('Visa •••• 4242')).toBe('4242');
+    expect(extractCardLast4('xxxx4242')).toBe('4242');
+  });
+
+  it('returns empty string when no last 4 is found', () => {
+    expect(extractCardLast4('Payment: PayPal balance')).toBe('');
+  });
+});
+
+describe('parsePaymentMethodFromText', () => {
+  it('returns brand + last4 + raw for a clean English match', () => {
+    const result = parsePaymentMethodFromText(
+      'Payment Method: Visa ending in 4242 — Order total $42.00'
+    );
+    expect(result).toEqual({
+      brand: 'Visa',
+      last4: '4242',
+      raw: 'Payment Method: Visa ending in 4242 — Order total $42.00',
+    });
+  });
+
+  it('falls back to brand "Card" when only last4 is detectable', () => {
+    const result = parsePaymentMethodFromText('Card ending in 4242');
+    expect(result).toEqual({
+      brand: 'Card',
+      last4: '4242',
+      raw: 'Card ending in 4242',
+    });
+  });
+
+  it('parses German order details copy', () => {
+    const result = parsePaymentMethodFromText(
+      'Zahlungsmethode: Mastercard endet auf 1111. Bestellt am 13. Mai 2026.'
+    );
+    expect(result?.brand).toBe('Mastercard');
+    expect(result?.last4).toBe('1111');
+  });
+
+  it('parses French order details copy', () => {
+    const result = parsePaymentMethodFromText(
+      'Mode de paiement : Visa se terminant par 9876. Commande passée le 13 mai 2026.'
+    );
+    expect(result?.brand).toBe('Visa');
+    expect(result?.last4).toBe('9876');
+  });
+
+  it('parses Spanish order details copy', () => {
+    const result = parsePaymentMethodFromText(
+      'Método de pago: American Express que termina en 0005. Pedido del 13 de mayo de 2026.'
+    );
+    expect(result?.brand).toBe('American Express');
+    expect(result?.last4).toBe('0005');
+  });
+
+  it('returns undefined when no card suffix can be found', () => {
+    expect(parsePaymentMethodFromText('Payment Method: PayPal')).toBeUndefined();
+    expect(parsePaymentMethodFromText('')).toBeUndefined();
+  });
+
+  it('truncates raw to a sensible length', () => {
+    const long = 'Some prefix '.repeat(40) + 'Visa ending in 4242 ' + 'tail '.repeat(40);
+    const result = parsePaymentMethodFromText(long);
+    expect(result?.raw.length).toBeLessThanOrEqual(120);
+  });
+});


### PR DESCRIPTION
## Summary

Amazon never exposes full card numbers (PCI-DSS), but the order details page renders the card brand and last 4 digits to the logged-in user. We piggyback on the existing per-order details fetch, so capture costs nothing extra in HTTP traffic.

Card brand and Card Last 4 are emitted as two new trailing CSV columns, and as a paymentMethod field in JSON (omitted when no card is detected — e.g. gift card balance, PayPal).

- new src/utils/paymentUtils.ts parses brand + last 4 with locale-aware patterns for en/de/fr/es and generic masked forms (**** 1234, •••• 1234, xxxx1234)
- recognises Visa, Mastercard, American Express, Discover, Diners Club, JCB, UnionPay; falls back to brand "Card" when only a suffix is detectable
- new CSV headers localized across all 4 supported locales
- 17 new tests covering brand detection, locale phrasing, raw truncation, fallback brand, and CSV column behaviour


I use Amazon for personal and business. Knowing which card was used for what transactions are important. I don't use Firefly III, but I assume this information would be valuable there too. 

## Related Issue

Closes #

## Maintainer Collaboration

- [x] I enabled **Allow edits from maintainers** on this PR.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore/maintenance

## Breaking Changes

- [ ] This PR introduces a breaking change.
- [ ] I documented migration or compatibility notes (if applicable).

## UI Changes

- [ ] This PR includes UI changes.
- [ ] I added screenshots or recordings for UI changes (if applicable).

## How Was This Tested?

List the commands and/or manual checks you ran.

```bash
npm run lint
npm run typecheck
npm run test
npm run format:check

npm run build 2>&1 | tail -20
   Target(s): firefox, chrome
   Mode: development

🔨 Building for firefox...
  ✓ TypeScript compiled (iife format)
  ✓ Static files copied
  ✓ Manifest copied (firefox-specific)
  ✓ Icons copied
  ✓ Locales copied
  ✅ firefox build completed → dist/firefox/

🔨 Building for chrome...
  ✓ TypeScript compiled (esm format)
  ✓ Static files copied
  ✓ Manifest copied (chrome-specific)
  ✓ Icons copied
  ✓ Locales copied
  ✅ chrome build completed → dist/chrome/

✅ All builds completed successfully!
```

## Checklist

- [ x] I verified the change locally.
- [x ] I added or updated tests when behavior changed.
- [x ] I updated documentation when needed.
- [x ] I updated locale/messages or metadata when needed.
- [x ] I confirmed no sensitive data was added.
