### PR TITLE
fix: price incorrectly parsed as 0 EUR in some orders

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "format:check": "prettier --check .",
     "clean": "node -e \"const fs = require('fs'); if(fs.existsSync('dist')) fs.rmSync('dist', {recursive: true})\"",
     "watch": "tsc --watch",
-    "test": "vitest run",
-    "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage",
+    "test": "TZ=UTC vitest run",
+    "test:watch": "TZ=UTC vitest",
+    "test:coverage": "TZ=UTC vitest run --coverage",
     "knip": "knip",
     "prepare": "husky"
   },

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "format:check": "prettier --check .",
     "clean": "node -e \"const fs = require('fs'); if(fs.existsSync('dist')) fs.rmSync('dist', {recursive: true})\"",
     "watch": "tsc --watch",
-    "test": "TZ=UTC vitest run",
-    "test:watch": "TZ=UTC vitest",
-    "test:coverage": "TZ=UTC vitest run --coverage",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
     "knip": "knip",
     "prepare": "husky"
   },

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -478,6 +478,15 @@ import {
   }
 
   /**
+   * Read an order card's text without injected <script>/<style> source to avoid polluting the regexes.
+   */
+  function getOrderCardText(orderEl: Element): string {
+    const clone = orderEl.cloneNode(true) as Element;
+    clone.querySelectorAll('script, style, noscript').forEach((el) => el.remove());
+    return clone.textContent || '';
+  }
+
+  /**
    * Parse a single order element
    */
   function parseOrderElement(orderEl: Element): Order | null {
@@ -493,7 +502,7 @@ import {
       totalSavings: 0,
     };
 
-    const orderText = orderEl.textContent || '';
+    const orderText = getOrderCardText(orderEl);
 
     // Extract Order ID
     order.orderId = extractOrderId(orderText) || '';

--- a/src/utils/priceUtils.ts
+++ b/src/utils/priceUtils.ts
@@ -60,22 +60,23 @@ export function detectCurrency(text: string): string {
  */
 export function extractPriceFromText(text: string): { amount: number; currency: string } | null {
   const pricePatterns = [
-    /(?:Summe|Gesamtsumme|Gesamt|Total)[:\s]*(?:EUR|€)?\s*([0-9.,]+)\s*(?:EUR|€)?/i,
-    /(?:EUR|€)\s*([0-9.,]+)/i,
-    /([0-9]+[.,][0-9]{2})\s*(?:EUR|€)/,
-    /\$\s*([0-9.,]+)/,
-    /£\s*([0-9.,]+)/,
+    /(?:Summe|Gesamtsumme|Gesamt|Total)[:\s]*(?:EUR|€|\$|£)?\s*([0-9][0-9.,]*)\s*(?:EUR|€|\$|£)?/gi,
+    /(?:EUR|€)\s*([0-9][0-9.,]*)/gi,
+    /([0-9]+[.,][0-9]{2})\s*(?:EUR|€)/g,
+    /\$\s*([0-9][0-9.,]*)/g,
+    /£\s*([0-9][0-9.,]*)/g,
   ];
 
   for (const pattern of pricePatterns) {
-    const match = text.match(pattern);
-    if (match?.[1]) {
-      const amount = parsePrice(match[1]);
-      if (amount > 0) {
-        return {
-          amount,
-          currency: detectCurrency(text),
-        };
+    for (const match of text.matchAll(pattern)) {
+      if (match[1]) {
+        const amount = parsePrice(match[1]);
+        if (amount > 0) {
+          return {
+            amount,
+            currency: detectCurrency(text),
+          };
+        }
       }
     }
   }

--- a/tests/priceUtils.test.ts
+++ b/tests/priceUtils.test.ts
@@ -138,5 +138,22 @@ describe('extractPriceFromText', () => {
     it('should not match zero amounts', () => {
       expect(extractPriceFromText('Total: €0,00')).toBeNull();
     });
+
+    it('should skip leading zero amounts and return the real total', () => {
+      const result = extractPriceFromText('$0.00 $0.00 $0.00 $252.71');
+      expect(result).toEqual({ amount: 252.71, currency: 'USD' });
+    });
+
+    it('should anchor on the labeled total when other amounts precede it', () => {
+      const result = extractPriceFromText(
+        'ORDER PLACED May 20, 2026 TOTAL $252.71 SHIP TO John Doe'
+      );
+      expect(result).toEqual({ amount: 252.71, currency: 'USD' });
+    });
+
+    it('should not treat a stray "$," token as a zero price', () => {
+      const result = extractPriceFromText('$, $252.71');
+      expect(result).toEqual({ amount: 252.71, currency: 'USD' });
+    });
   });
 });


### PR DESCRIPTION
## Summary

On the orders list page, some order cards (e.g. Renewed items that show the protection-plan / "get product support" UI) embed inline `<script>` source plus hidden zero-valued price nodes. The price parser read the card's raw `textContent`, locked onto the first `$` token it found (a script artifact or a `$0`), and gave up before reaching the real total. Those orders were exported as `0` with the default `EUR` currency instead of the real amount and currency. Most orders carry no such noise, so they parsed fine.

## Technical Overview

- Order-card text is now read with `<script>`/`<style>`/`<noscript>` stripped, so injected JS source can't pollute price/date/order-id parsing.
- `extractPriceFromText` prefers the labeled total (now also recognizing `$`/`£`), requires captures to start with a digit, and scans every match for a pattern, returning the first positive amount instead of bailing on the first hit.

## Maintainer Collaboration

- [x] I enabled **Allow edits from maintainers** on this PR.

## Type of Change

- [x] Bug fix

## How Was This Tested?

```bash
npm run lint
npm run typecheck
npm run test
npm run format:check
```

All 143 unit tests pass; added regression tests covering the price parser.

## Checklist

- [x] I verified the change locally.
- [x] I added or updated tests when behavior changed.
- [x] I confirmed no sensitive data was added.