### PR TITLE
Feat/transaction dates amounts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,72 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+npm run build              # typecheck + lint + build both browser targets
+npm run build:firefox      # build Firefox extension only
+npm run build:chrome       # build Chrome extension only
+npm run build:prod         # production build (minified) for all browsers
+npm run typecheck          # TypeScript strict checks (no emit)
+npm run lint               # ESLint on src/**/*.ts
+npm run lint:fix           # ESLint with auto-fixes
+npm run format:check       # Prettier check
+npm run format             # Prettier write
+npm run test               # run all Vitest tests
+npm run test:coverage      # run tests with coverage report
+npm run knip               # find unused exports/files/dependencies
+npm run bump -- bugfix     # bump version (also: major, minor) across package.json + manifests
+```
+
+Run a single test file:
+```bash
+npx vitest run tests/dateUtils.test.ts
+```
+
+The pre-commit hook runs `lint` and `format:check`. Run `npm run prepare` to reinstall Husky hooks if missing.
+
+## Architecture
+
+This is a dual-target browser extension (Firefox MV2 + Chrome MV3) with three entry points compiled by esbuild (`build.js`):
+
+**`src/content/content.ts`** — Content script injected into Amazon order history pages. Orchestrates the entire export flow: discovers year filters, navigates through paginated order lists, scrapes order cards, and fetches individual order detail pages for accurate item prices and promotions. Export state is persisted in `sessionStorage` under the key `amazonExporter` so it survives the page navigations required to walk through multiple years and pages.
+
+**`src/background/background.ts`** — Background script (service worker on Chrome MV3, persistent script on Firefox MV2). Handles file downloads and forwards `updateProgress` messages from the content script to the popup. Chrome MV3 service workers lack `Blob`/`URL.createObjectURL`, so downloads use base64 data URLs there; Firefox uses Blob URLs.
+
+**`src/popup/popup.ts`** — Popup UI. Collects export options (format, date range) and sends an `exportOrders` message to the content script to start the export.
+
+**`src/utils/*.ts`** — All parsing logic lives here: date formats (German/English/French), price/currency extraction, order status localization, CSV generation, URL detection and construction. These are the only files with unit test coverage.
+
+**`src/types/index.ts`** — Shared TypeScript interfaces: `Order`, `OrderItem`, `Promotion`, `ExportState`, `ExportOptions`, `DownloadData`, `MessagePayload`.
+
+**`src/_locales/`** — i18n strings for de, en, es, fr. All user-facing strings go through `browser.i18n.getMessage`.
+
+**`src/manifest.chrome.json` / `src/manifest.firefox.json`** — Both must be updated together when changing permissions, URL match patterns, or extension entry points.
+
+## Cross-browser constraints
+
+- Chrome MV3 service worker has no DOM APIs and no `Blob`/`createObjectURL` — the download path handles this explicitly in `background.ts`.
+- Firefox MV2 uses IIFE bundle format; Chrome MV3 uses ESM. This is configured in `build.js` per target.
+- `webextension-polyfill` normalizes the `browser.*` API surface across both browsers.
+
+## Test coverage
+
+Unit tests in `tests/` cover `src/utils/` only — these run in a Node/Vitest environment without browser globals. The content script, background, and popup are not unit tested. Each utility file maps directly to a test file:
+
+| Source | Test |
+|--------|------|
+| `src/utils/dateUtils.ts` | `tests/dateUtils.test.ts` |
+| `src/utils/priceUtils.ts` | `tests/priceUtils.test.ts` |
+| `src/utils/orderUtils.ts` | `tests/orderUtils.test.ts` |
+| `src/utils/csvUtils.ts` | `tests/csvUtils.test.ts` |
+| `src/utils/urlUtils.ts` | `tests/urlUtils.test.ts` |
+| `src/utils/statusUtils.ts` | `tests/statusUtils.test.ts` |
+
+## Key conventions
+
+- If the exported data shape (`Order`, `OrderItem`, etc.) changes, update `src/types/index.ts`, JSON/CSV generation, tests, and the README schema docs together.
+- i18n keys must stay in sync across all four locale files when adding/removing user-facing strings.
+- Do not edit files under `dist/` — they are build artifacts.
+- Do not run `npm run watch` or `npm run test:watch` — interactive/long-lived commands are not appropriate in this repo's CI context.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Browser extension for exporting your Amazon order history to JSON or CSV format.
 - **Full History Export** — Export your entire Amazon order history
 - **Date Range Filtering** — Export orders within a specific date range
 - **Multiple Formats** — Export as JSON or CSV
+- **Transaction Details** — Optionally include the actual charged amount and transaction date per order, sourced from Amazon's payments page (not the pre-tax subtotal)
 - **Privacy Focused** — No tracking or data collection; all processing happens locally
 - **Open Source** — Free to use and modify
 
@@ -83,7 +84,8 @@ The built extensions will be in browser-specific directories:
 2. Navigate to Amazon and log in to your account
 3. Click the extension icon in the toolbar
 4. Select your export options (date range, format)
-5. Click "Export" to download your order history
+5. Optionally check **Include transaction details** to add the actual charged amount and transaction date to each order — this fetches one extra page per order so exports will take longer
+6. Click "Export" to download your order history
 
 ---
 
@@ -91,7 +93,7 @@ The built extensions will be in browser-specific directories:
 
 ### JSON Format
 
-The data model for each order includes the following fields:
+The data model for each order includes the following fields. The `transactions` field is only present when "Include transaction details" is enabled.
 
 ```json
 {
@@ -117,7 +119,14 @@ The data model for each order includes the following fields:
             "amount": "number"
         }
     ],
-    "totalSavings": "number"
+    "totalSavings": "number",
+    "transactions": [
+        {
+            "date": "string (ISO 8601 date)",
+            "amount": "number (positive = charge, negative = refund)",
+            "currency": "string"
+        }
+    ]
 }
 ```
 
@@ -141,6 +150,8 @@ The CSV export creates multiple rows for orders with multiple items. Columns:
 | Promotions | Applied promotions |
 | Item URL | Link to product page |
 | Details URL | Link to order details |
+| Transaction Dates | Date(s) Amazon charged your payment method (pipe-separated if multiple); only present when "Include transaction details" is enabled |
+| Transaction Amounts | Charged amount(s) — positive for charges, negative for refunds (pipe-separated if multiple); only present when "Include transaction details" is enabled |
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@eslint/js": "9.39.2",
+        "@types/jsdom": "^28.0.3",
         "@types/webextension-polyfill": "0.12.4",
         "@typescript-eslint/eslint-plugin": "8.54.0",
         "@typescript-eslint/parser": "8.54.0",
@@ -21,11 +22,63 @@
         "eslint": "9.39.2",
         "eslint-config-prettier": "^10.1.8",
         "husky": "^9.1.7",
+        "jsdom": "^29.1.1",
         "knip": "5.82.1",
         "prettier": "^3.8.1",
         "typescript": "5.9.3",
         "vitest": "4.0.18"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
@@ -85,6 +138,161 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
+      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
+      "integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -750,6 +958,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanfs/core": {
@@ -1563,6 +1789,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jsdom": {
+      "version": "28.0.3",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-28.0.3.tgz",
+      "integrity": "sha512-/HQ2uFoetFTXuye8vzIcHw2z6Fwi7Hi/qcgC+RoS9NCyewiqxhVGqlG+ViGB6lkax481R6dmhf1I7lIGlzJStQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^8.0.0",
+        "undici-types": "^7.21.0"
+      }
+    },
+    "node_modules/@types/jsdom/node_modules/undici-types": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.27.2.tgz",
+      "integrity": "sha512-cH9f42mHuljpNuoS47sWDDWXVxWnJgYCzHVUlr3tn7+HVx0L6QSO+VG5qgzT4kXkR2K8ZsReaT5bupam6RNAEQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1580,6 +1826,13 @@
       "dependencies": {
         "undici-types": "~7.16.0"
       }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/webextension-polyfill": {
       "version": "0.12.4",
@@ -1623,6 +1876,7 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -1969,6 +2223,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2054,6 +2309,16 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
@@ -2157,6 +2422,34 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2175,12 +2468,32 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
@@ -2250,6 +2563,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2714,6 +3028,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -2807,6 +3134,13 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2859,6 +3193,7 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -2881,6 +3216,48 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/json-buffer": {
@@ -3006,6 +3383,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3043,6 +3430,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -3246,6 +3640,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3379,6 +3786,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3467,6 +3884,19 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/semver": {
@@ -3575,6 +4005,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -3619,6 +4056,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.2.tgz",
+      "integrity": "sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.2"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.2.tgz",
+      "integrity": "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -3630,6 +4087,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -3672,6 +4155,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3680,13 +4164,22 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
+      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -3704,6 +4197,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -3779,6 +4273,7 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -3851,6 +4346,19 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/walk-up-path": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz",
@@ -3866,6 +4374,41 @@
       "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.12.0.tgz",
       "integrity": "sha512-97TBmpoWJEE+3nFBQ4VocyCdLKfw54rFaJ6EVQYLBCXqCIpLSZkwGgASpv4oPt9gdKCJ80RJlcmNzNn008Ag6Q==",
       "license": "MPL-2.0"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -3909,6 +4452,23 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "license": "MIT",
   "devDependencies": {
     "@eslint/js": "9.39.2",
+    "@types/jsdom": "^28.0.3",
     "@types/webextension-polyfill": "0.12.4",
     "@typescript-eslint/eslint-plugin": "8.54.0",
     "@typescript-eslint/parser": "8.54.0",
@@ -44,6 +45,7 @@
     "eslint": "9.39.2",
     "eslint-config-prettier": "^10.1.8",
     "husky": "^9.1.7",
+    "jsdom": "^29.1.1",
     "knip": "5.82.1",
     "prettier": "^3.8.1",
     "typescript": "5.9.3",

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -113,6 +113,24 @@
       }
     }
   },
+  "includeTransactions": {
+    "message": "Transaktionsdetails einschließen",
+    "description": "Checkbox label to include per-order transaction data"
+  },
+  "includeTransactionsHint": {
+    "message": "Lädt eine zusätzliche Seite pro Bestellung – langsamer",
+    "description": "Hint text below the include transactions checkbox"
+  },
+  "fetchingPricesAndTransactions": {
+    "message": "Lade Preise und Transaktionen für $COUNT$ Bestellungen...",
+    "description": "Progress message when fetching both prices and transactions",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "25"
+      }
+    }
+  },
   "fetchingPrices": {
     "message": "Lade Preise für $COUNT$ Bestellungen...",
     "description": "Progress message while fetching prices",
@@ -218,5 +236,13 @@
   "csvHeaderDetailsUrl": {
     "message": "Details-Link",
     "description": "CSV header for details URL"
+  },
+  "csvHeaderTransactionDates": {
+    "message": "Transaktionsdaten",
+    "description": "CSV header for transaction dates"
+  },
+  "csvHeaderTransactionAmounts": {
+    "message": "Transaktionsbeträge",
+    "description": "CSV header for transaction amounts"
   }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -113,6 +113,24 @@
       }
     }
   },
+  "includeTransactions": {
+    "message": "Include transaction details",
+    "description": "Checkbox label to include per-order transaction data"
+  },
+  "includeTransactionsHint": {
+    "message": "Fetches an extra page per order — slower",
+    "description": "Hint text below the include transactions checkbox"
+  },
+  "fetchingPricesAndTransactions": {
+    "message": "Fetching prices and transactions for $COUNT$ orders...",
+    "description": "Progress message when fetching both prices and transactions",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "25"
+      }
+    }
+  },
   "fetchingPrices": {
     "message": "Fetching item prices for $COUNT$ orders...",
     "description": "Progress message while fetching prices",
@@ -218,5 +236,13 @@
   "csvHeaderDetailsUrl": {
     "message": "Details URL",
     "description": "CSV header for details URL"
+  },
+  "csvHeaderTransactionDates": {
+    "message": "Transaction Dates",
+    "description": "CSV header for transaction dates"
+  },
+  "csvHeaderTransactionAmounts": {
+    "message": "Transaction Amounts",
+    "description": "CSV header for transaction amounts"
   }
 }

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -113,6 +113,24 @@
       }
     }
   },
+  "includeTransactions": {
+    "message": "Incluir detalles de transacción",
+    "description": "Checkbox label to include per-order transaction data"
+  },
+  "includeTransactionsHint": {
+    "message": "Obtiene una página extra por pedido — más lento",
+    "description": "Hint text below the include transactions checkbox"
+  },
+  "fetchingPricesAndTransactions": {
+    "message": "Obteniendo precios y transacciones para $COUNT$ pedidos...",
+    "description": "Progress message when fetching both prices and transactions",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "25"
+      }
+    }
+  },
   "fetchingPrices": {
     "message": "Obteniendo precios de artículos para $COUNT$ pedidos...",
     "description": "Progress message while fetching prices",
@@ -218,5 +236,13 @@
   "csvHeaderDetailsUrl": {
     "message": "URL de detalles",
     "description": "CSV header for details URL"
+  },
+  "csvHeaderTransactionDates": {
+    "message": "Fechas de transacción",
+    "description": "CSV header for transaction dates"
+  },
+  "csvHeaderTransactionAmounts": {
+    "message": "Importes de transacción",
+    "description": "CSV header for transaction amounts"
   }
 }

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -113,6 +113,24 @@
       }
     }
   },
+  "includeTransactions": {
+    "message": "Inclure les détails de transaction",
+    "description": "Checkbox label to include per-order transaction data"
+  },
+  "includeTransactionsHint": {
+    "message": "Récupère une page supplémentaire par commande — plus lent",
+    "description": "Hint text below the include transactions checkbox"
+  },
+  "fetchingPricesAndTransactions": {
+    "message": "Récupération des prix et transactions pour $COUNT$ commandes...",
+    "description": "Progress message when fetching both prices and transactions",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "25"
+      }
+    }
+  },
   "fetchingPrices": {
     "message": "Récupération des prix pour $COUNT$ commandes...",
     "description": "Progress message while fetching prices",
@@ -218,5 +236,13 @@
   "csvHeaderDetailsUrl": {
     "message": "URL des détails",
     "description": "CSV header for details URL"
+  },
+  "csvHeaderTransactionDates": {
+    "message": "Dates de transaction",
+    "description": "CSV header for transaction dates"
+  },
+  "csvHeaderTransactionAmounts": {
+    "message": "Montants des transactions",
+    "description": "CSV header for transaction amounts"
   }
 }

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -19,6 +19,8 @@ import {
   extractPriceFromText,
   parsePrice,
   parseOrderStatus,
+  buildTransactionUrl,
+  parseTransactionsFromCPEPage,
 } from '../utils';
 
 (function (): void {
@@ -59,7 +61,13 @@ import {
   function getExportState(): ExportState | null {
     try {
       const data = sessionStorage.getItem(STORAGE_KEY);
-      return data ? (JSON.parse(data) as ExportState) : null;
+      if (!data) return null;
+      const state = JSON.parse(data) as ExportState;
+      // Default field added in a later version — ensure backward compatibility
+      if (typeof state.includeTransactions !== 'boolean') {
+        state.includeTransactions = false;
+      }
+      return state;
     } catch {
       return null;
     }
@@ -130,6 +138,7 @@ import {
       startDate: startDate,
       endDate: endDate,
       exportAll: exportAll,
+      includeTransactions: options.includeTransactions,
       yearsToProcess: yearsToProcess,
       currentYearIndex: 0,
       currentStartIndex: 0,
@@ -180,7 +189,7 @@ import {
     const endDateObj = state.endDate ? new Date(state.endDate) : null;
 
     // Scrape orders from current page
-    const pageOrders = scrapeVisibleOrders(
+    const { orders: pageOrders, passedStartDate } = scrapeVisibleOrders(
       startDateObj,
       endDateObj,
       state.exportAll,
@@ -200,7 +209,11 @@ import {
     // Check if there are more pages for current year
     const hasNextPage = checkForNextPage();
 
-    if (hasNextPage && pageOrders.length > 0) {
+    // Continue to the next page if Amazon shows one AND we haven't gone past the
+    // start date yet. In date-range mode, Amazon lists orders newest-first, so
+    // early pages may have zero matches (all too new) — we must keep paginating
+    // until we either find matches or encounter orders older than startDate.
+    if (hasNextPage && !passedStartDate) {
       // Navigate to next page of current year
       state.currentStartIndex += 10;
       saveExportState(state);
@@ -241,10 +254,19 @@ import {
   async function finishExport(state: ExportState): Promise<void> {
     console.log('[Amazon Exporter] Export complete. Total orders:', state.collectedOrders.length);
 
-    updateProgress(80, getMessage('fetchingPrices', [String(state.collectedOrders.length)]));
+    updateProgress(
+      80,
+      state.includeTransactions
+        ? getMessage('fetchingPricesAndTransactions', [String(state.collectedOrders.length)])
+        : getMessage('fetchingPrices', [String(state.collectedOrders.length)])
+    );
 
-    // Fetch item prices for multi-item orders
-    await fetchOrderDetailsForPrices(state.collectedOrders);
+    // Fetch item prices (and optionally transaction details) for all orders
+    await fetchOrderDetailsForPrices(
+      state.collectedOrders,
+      state.includeTransactions,
+      state.baseUrl
+    );
 
     updateProgress(95, getMessage('generatingFile'));
 
@@ -259,7 +281,7 @@ import {
       fileName = `amazon-orders-${timestamp}.json`;
       mimeType = 'application/json';
     } else {
-      fileContent = convertToCSV(state.collectedOrders);
+      fileContent = convertToCSV(state.collectedOrders, state.includeTransactions);
       fileName = `amazon-orders-${timestamp}.csv`;
       mimeType = 'text/csv';
     }
@@ -391,8 +413,9 @@ import {
     endDateObj: Date | null,
     exportAll: boolean,
     seenOrderIds: Set<string>
-  ): Order[] {
+  ): { orders: Order[]; passedStartDate: boolean } {
     const orders: Order[] = [];
+    let passedStartDate = false;
 
     console.log('[Amazon Exporter] Scraping visible page...');
     console.log('[Amazon Exporter] URL:', window.location.href);
@@ -459,7 +482,19 @@ import {
           // Filter by date if specified
           if (!exportAll && startDateObj && endDateObj && order.orderDate) {
             const orderDateObj = new Date(order.orderDate);
-            if (orderDateObj < startDateObj || orderDateObj > endDateObj) {
+            if (orderDateObj < startDateObj) {
+              // This order is older than our start date. Since Amazon lists orders
+              // newest-first, all subsequent pages will also be out-of-range.
+              passedStartDate = true;
+              console.log(
+                `[Amazon Exporter] Skipping order ${order.orderId}: date ${order.orderDate} before range start ${startDateObj.toISOString().split('T')[0]}`
+              );
+              return;
+            }
+            if (orderDateObj > endDateObj) {
+              console.log(
+                `[Amazon Exporter] Skipping order ${order.orderId}: date ${order.orderDate} after range end ${endDateObj.toISOString().split('T')[0]}`
+              );
               return;
             }
           }
@@ -474,7 +509,7 @@ import {
       }
     });
 
-    return orders;
+    return { orders, passedStartDate };
   }
 
   /**
@@ -498,7 +533,7 @@ import {
     // Extract Order ID
     order.orderId = extractOrderId(orderText) || '';
 
-    // Try links for order ID
+    // Try links for order ID via orderID=/orderId= query param
     if (!order.orderId) {
       const links = orderEl.querySelectorAll('a[href]');
       for (const link of links) {
@@ -509,6 +544,46 @@ import {
           break;
         }
       }
+    }
+
+    // Try data attributes on the order element and its children
+    if (!order.orderId) {
+      const attrTargets: (Element | null)[] = [
+        orderEl,
+        ...Array.from(orderEl.querySelectorAll('[data-order-id], [data-orderid], [data-order]')),
+      ];
+      for (const el of attrTargets) {
+        if (!el) continue;
+        const raw =
+          el.getAttribute('data-order-id') ||
+          el.getAttribute('data-orderid') ||
+          el.getAttribute('data-order') ||
+          el.id ||
+          '';
+        const match = raw.match(/\d{3}-\d{7}-\d{7}/);
+        if (match?.[0]) {
+          order.orderId = match[0];
+          break;
+        }
+      }
+    }
+
+    // Last resort: scan every link href for the order ID pattern directly
+    if (!order.orderId) {
+      const allLinks = orderEl.querySelectorAll('a[href]');
+      for (const link of allLinks) {
+        const href = (link as HTMLAnchorElement).href || link.getAttribute('href') || '';
+        const match = href.match(/\d{3}-\d{7}-\d{7}/);
+        if (match?.[0]) {
+          order.orderId = match[0];
+          break;
+        }
+      }
+    }
+
+    if (!order.orderId) {
+      const snippet = orderText.replace(/\s+/g, ' ').trim().substring(0, 150);
+      console.warn(`[Amazon Exporter] Could not extract order ID. Card text: "${snippet}"`);
     }
 
     // Extract order details URL
@@ -655,14 +730,25 @@ import {
   }
 
   /**
-   * Fetch order details for item prices and discounts
+   * Fetch order details for item prices, discounts, and (optionally) transactions
    */
-  async function fetchOrderDetailsForPrices(orders: Order[]): Promise<void> {
-    // We need to fetch details for all orders to get accurate pricing and discounts
-    // Even single-item orders can have discounts
+  async function fetchOrderDetailsForPrices(
+    orders: Order[],
+    includeTransactions: boolean,
+    baseUrl: string
+  ): Promise<void> {
     const ordersNeedingDetails = orders.filter((order) => order.detailsUrl);
 
     console.log('[Amazon Exporter] Fetching details for', ordersNeedingDetails.length, 'orders');
+
+    let transactionOrigin = '';
+    if (includeTransactions) {
+      try {
+        transactionOrigin = new URL(baseUrl).origin;
+      } catch {
+        console.warn('[Amazon Exporter] Could not determine origin for transaction URLs');
+      }
+    }
 
     for (let i = 0; i < ordersNeedingDetails.length; i++) {
       const order = ordersNeedingDetails[i];
@@ -678,14 +764,43 @@ import {
           credentials: 'include',
         });
 
-        if (!response.ok) continue;
+        if (response.ok) {
+          const html = await response.text();
+          const parser = new DOMParser();
+          const doc = parser.parseFromString(html, 'text/html');
+          parseItemPricesFromDetails(order, doc);
+          parsePromotionsFromDetails(order, doc);
+        }
 
-        const html = await response.text();
-        const parser = new DOMParser();
-        const doc = parser.parseFromString(html, 'text/html');
+        // Fetch the CPE transaction page for actual charged amounts
+        if (includeTransactions && transactionOrigin && order.orderId) {
+          await new Promise((resolve) => setTimeout(resolve, 200));
 
-        parseItemPricesFromDetails(order, doc);
-        parsePromotionsFromDetails(order, doc);
+          const txUrl = buildTransactionUrl(transactionOrigin, order.orderId);
+          try {
+            const txResponse = await fetch(txUrl, { credentials: 'include' });
+            if (txResponse.ok) {
+              const txHtml = await txResponse.text();
+              order.transactions = parseTransactionsFromCPEPage(txHtml);
+              if (order.transactions.length > 0) {
+                console.log(
+                  `[Amazon Exporter] ${order.transactions.length} transaction(s) from CPE page for order ${order.orderId}`
+                );
+              } else {
+                console.warn(
+                  `[Amazon Exporter] No transactions found in CPE page for ${order.orderId}`
+                );
+              }
+            }
+          } catch (txError) {
+            console.warn(
+              '[Amazon Exporter] Error fetching transactions for order:',
+              order.orderId,
+              txError
+            );
+            order.transactions = [];
+          }
+        }
 
         await new Promise((resolve) => setTimeout(resolve, 200));
       } catch (error) {
@@ -904,8 +1019,8 @@ import {
   /**
    * Convert orders to CSV format (wrapper using utility function)
    */
-  function convertToCSV(orders: Order[]): string {
-    return convertOrdersToCSV(orders, getMessage);
+  function convertToCSV(orders: Order[], includeTransactions: boolean): string {
+    return convertOrdersToCSV(orders, getMessage, includeTransactions);
   }
 
   /**

--- a/src/manifest.chrome.json
+++ b/src/manifest.chrome.json
@@ -9,7 +9,7 @@
     "96": "icons/icon-96.png",
     "128": "icons/icon-128.png"
   },
-  "permissions": ["activeTab", "downloads"],
+  "permissions": ["activeTab", "downloads", "storage"],
   "host_permissions": [
     "*://*.amazon.com/*",
     "*://*.amazon.co.uk/*",

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -11,6 +11,7 @@
   "permissions": [
     "activeTab",
     "downloads",
+    "storage",
     "*://*.amazon.com/*",
     "*://*.amazon.co.uk/*",
     "*://*.amazon.de/*",

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -246,6 +246,40 @@ footer a:hover {
   display: none !important;
 }
 
+.checkbox-label {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  cursor: pointer;
+  padding: 10px 12px;
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  transition: all 0.2s ease;
+}
+
+.checkbox-label:hover {
+  border-color: #ff9900;
+  background: #fff8e5;
+}
+
+.checkbox-label input[type='checkbox'] {
+  margin-top: 2px;
+  accent-color: #ff9900;
+  flex-shrink: 0;
+}
+
+.checkbox-content {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.hint {
+  font-size: 11px;
+  color: #888;
+}
+
 /* Smooth transition for settings visibility */
 #settings-section {
   transition: opacity 0.2s ease;

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -66,6 +66,18 @@
               </label>
             </div>
           </section>
+
+          <section class="section">
+            <label class="checkbox-label">
+              <input type="checkbox" id="includeTransactions" />
+              <div class="checkbox-content">
+                <span data-i18n="includeTransactions">Include transaction details</span>
+                <span class="hint" data-i18n="includeTransactionsHint"
+                  >Fetches an extra page per order — slower</span
+                >
+              </div>
+            </label>
+          </section>
         </div>
 
         <section class="section">

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -45,6 +45,17 @@ document.addEventListener('DOMContentLoaded', async () => {
   const startDateInput = document.getElementById('startDate') as HTMLInputElement;
   const endDateInput = document.getElementById('endDate') as HTMLInputElement;
   const settingsSection = document.getElementById('settings-section') as HTMLElement;
+  const includeTransactionsCheckbox = document.getElementById(
+    'includeTransactions'
+  ) as HTMLInputElement;
+
+  // Restore persisted checkbox state
+  const stored = await browser.storage.local.get('includeTransactions');
+  includeTransactionsCheckbox.checked = stored['includeTransactions'] === true;
+
+  includeTransactionsCheckbox.addEventListener('change', () => {
+    void browser.storage.local.set({ includeTransactions: includeTransactionsCheckbox.checked });
+  });
 
   // Set default date values
   const today = new Date();
@@ -124,6 +135,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         startDate: startDate,
         endDate: endDate,
         exportAll: exportRange === 'all',
+        includeTransactions: includeTransactionsCheckbox.checked,
       };
 
       // Send message to content script

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,6 +11,12 @@ export interface OrderItem {
   itemUrl: string;
 }
 
+export interface Transaction {
+  date: string;
+  amount: number;
+  currency: string;
+}
+
 export interface Order {
   orderId: string;
   orderDate: string;
@@ -21,6 +27,7 @@ export interface Order {
   detailsUrl: string;
   promotions: Promotion[];
   totalSavings: number;
+  transactions?: Transaction[];
 }
 
 export interface Promotion {
@@ -33,6 +40,7 @@ export interface ExportOptions {
   startDate: string | null;
   endDate: string | null;
   exportAll: boolean;
+  includeTransactions: boolean;
 }
 
 export interface ExportState {
@@ -41,6 +49,7 @@ export interface ExportState {
   startDate: string | null;
   endDate: string | null;
   exportAll: boolean;
+  includeTransactions: boolean;
   yearsToProcess: string[];
   currentYearIndex: number;
   currentStartIndex: number;

--- a/src/utils/csvUtils.ts
+++ b/src/utils/csvUtils.ts
@@ -3,6 +3,7 @@
  */
 
 import type { Order } from '../types';
+import { formatTransactionDatesForCSV, formatTransactionAmountsForCSV } from './transactionUtils';
 
 /**
  * Escape a value for CSV format
@@ -30,10 +31,12 @@ export function formatPromotionsForCSV(
  * Convert orders to CSV format
  * @param orders - Array of orders to convert
  * @param getHeader - Function to get localized header name
+ * @param includeTransactions - Whether to add Transaction Dates and Transaction Amounts columns
  */
 export function convertOrdersToCSV(
   orders: Order[],
-  getHeader: (key: string) => string = (key) => key
+  getHeader: (key: string) => string = (key) => key,
+  includeTransactions: boolean = false
 ): string {
   const headers = [
     getHeader('csvHeaderOrderId'),
@@ -52,10 +55,27 @@ export function convertOrdersToCSV(
     getHeader('csvHeaderDetailsUrl'),
   ];
 
+  if (includeTransactions) {
+    headers.push(getHeader('csvHeaderTransactionDates'));
+    headers.push(getHeader('csvHeaderTransactionAmounts'));
+  }
+
   const rows: string[] = [headers.join(',')];
 
   orders.forEach((order) => {
     const promotionsStr = formatPromotionsForCSV(order.promotions);
+    const transactions = order.transactions ?? [];
+    const txDates = includeTransactions
+      ? escapeCSVValue(formatTransactionDatesForCSV(transactions))
+      : null;
+    const txAmounts = includeTransactions
+      ? escapeCSVValue(formatTransactionAmountsForCSV(transactions))
+      : null;
+
+    const txColumns = (firstRow: boolean): (string | number)[] => {
+      if (!includeTransactions) return [];
+      return firstRow ? [txDates ?? '', txAmounts ?? ''] : ['', ''];
+    };
 
     if (order.items.length === 0) {
       rows.push(
@@ -74,6 +94,7 @@ export function convertOrdersToCSV(
           escapeCSVValue(promotionsStr),
           '',
           escapeCSVValue(order.detailsUrl),
+          ...txColumns(true),
         ].join(',')
       );
     } else {
@@ -94,6 +115,7 @@ export function convertOrdersToCSV(
             index === 0 ? escapeCSVValue(promotionsStr) : '',
             escapeCSVValue(item.itemUrl),
             escapeCSVValue(order.detailsUrl),
+            ...txColumns(index === 0),
           ].join(',')
         );
       });

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -8,3 +8,4 @@ export * from './orderUtils';
 export * from './statusUtils';
 export * from './csvUtils';
 export * from './urlUtils';
+export * from './transactionUtils';

--- a/src/utils/priceUtils.ts
+++ b/src/utils/priceUtils.ts
@@ -82,3 +82,34 @@ export function extractPriceFromText(text: string): { amount: number; currency: 
 
   return null;
 }
+
+/**
+ * Like extractPriceFromText but returns negative amounts for refunds/credits.
+ * Negates the amount when:
+ * - The text has an explicit minus sign before the currency symbol or amount, OR
+ * - The text contains a refund/credit keyword in any supported locale.
+ */
+export function extractSignedPriceFromText(
+  text: string
+): { amount: number; currency: string } | null {
+  // Explicit negative sign adjacent to a currency symbol or number
+  const hasMinusSign =
+    /(?:^|[\s(])[-−]\s*(?:EUR|€|\$|£|USD|GBP)\s*[0-9]/.test(text) ||
+    /(?:EUR|€|\$|£|USD|GBP)\s*[-−]\s*[0-9]/.test(text);
+
+  // Refund/credit keywords (EN, DE, FR, IT, ES).
+  // French keywords ending in é/ée cannot use \b (é is non-ASCII → no word boundary),
+  // so they are matched separately with a simple substring check.
+  const isRefundContext =
+    /\b(?:refund(?:ed)?|return(?:ed)?|r[uü]ckerstattung|erstattung|gutschrift|remboursement|rimborso|reembolso(?:ado)?)\b/i.test(
+      text
+    ) || /rembours/i.test(text);
+
+  const price = extractPriceFromText(text);
+  if (!price) return null;
+
+  return {
+    amount: hasMinusSign || isRefundContext ? -price.amount : price.amount,
+    currency: price.currency,
+  };
+}

--- a/src/utils/transactionUtils.ts
+++ b/src/utils/transactionUtils.ts
@@ -1,0 +1,79 @@
+/**
+ * Transaction URL building, CSV formatting, and CPE page parsing utilities
+ */
+
+import type { Transaction } from '../types';
+import { parseOrderDate } from './dateUtils';
+import { extractPriceFromText } from './priceUtils';
+
+/**
+ * Build the URL for an order's transaction detail page
+ */
+export function buildTransactionUrl(origin: string, orderId: string): string {
+  return `${origin}/cpe/yourpayments/transactions?transactionTag=${encodeURIComponent(orderId)}`;
+}
+
+/**
+ * Format transaction dates as a pipe-separated string for CSV
+ */
+export function formatTransactionDatesForCSV(transactions: Transaction[]): string {
+  if (transactions.length === 0) return '';
+  return transactions.map((t) => t.date).join(' | ');
+}
+
+/**
+ * Format transaction amounts as a pipe-separated string for CSV
+ */
+export function formatTransactionAmountsForCSV(transactions: Transaction[]): string {
+  if (transactions.length === 0) return '';
+  return transactions.map((t) => String(t.amount)).join(' | ');
+}
+
+/**
+ * Parse transactions from the /cpe/yourpayments/transactions page.
+ * Amazon's CPE page is server-rendered and contains the actual charged amounts.
+ *
+ * Sign convention: Amazon shows charges as "-$X.XX" (debit from card) and
+ * refunds as "$X.XX" (credit to card). We negate so the export reflects the
+ * user's perspective — charges are positive, refunds are negative.
+ */
+export function parseTransactionsFromCPEPage(html: string): Transaction[] {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(html, 'text/html');
+  const transactions: Transaction[] = [];
+  const seen = new Set<string>();
+
+  // Each transaction group is an .a-box-group containing .apx-transaction-date-container
+  const groups = doc.querySelectorAll('.a-box-group');
+  for (const group of groups) {
+    const dateEl = group.querySelector('.apx-transaction-date-container span');
+    if (!dateEl) continue;
+
+    const dateText = dateEl.textContent?.trim() ?? '';
+    const date = parseOrderDate(dateText);
+    if (!date) continue;
+
+    const amountEls = group.querySelectorAll(
+      '.a-column.a-span3.a-text-right.a-span-last .a-size-base-plus.a-text-bold,' +
+        '.apx-transactions-line-item-component-container .a-size-base-plus.a-text-bold'
+    );
+
+    for (const amountEl of amountEls) {
+      const amountText = amountEl.textContent?.trim() ?? '';
+      if (!amountText) continue;
+
+      const isDebit = /^[-−]/.test(amountText);
+      const price = extractPriceFromText(amountText);
+      if (!price || price.amount === 0) continue;
+
+      const amount = isDebit ? price.amount : -price.amount;
+      const key = `${date}:${amount}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        transactions.push({ date, amount, currency: price.currency });
+      }
+    }
+  }
+
+  return transactions;
+}

--- a/tests/csvUtils.test.ts
+++ b/tests/csvUtils.test.ts
@@ -176,4 +176,95 @@ describe('convertOrdersToCSV', () => {
     const csv = convertOrdersToCSV(orders);
     expect(csv).toContain('"Product ""with quotes"", and commas"');
   });
+
+  describe('transaction columns', () => {
+    it('should not include transaction columns when includeTransactions is false', () => {
+      const orders = [createOrder()];
+      const csv = convertOrdersToCSV(orders, undefined, false);
+      expect(csv).not.toContain('csvHeaderTransactionDates');
+      expect(csv).not.toContain('csvHeaderTransactionAmounts');
+      const headerCols = csv.split('\n')[0]!.split(',');
+      expect(headerCols.length).toBe(14);
+    });
+
+    it('should include transaction columns when includeTransactions is true', () => {
+      const orders = [createOrder()];
+      const csv = convertOrdersToCSV(orders, undefined, true);
+      expect(csv).toContain('csvHeaderTransactionDates');
+      expect(csv).toContain('csvHeaderTransactionAmounts');
+      const headerCols = csv.split('\n')[0]!.split(',');
+      expect(headerCols.length).toBe(16);
+    });
+
+    it('should populate transaction columns from order.transactions on first item row', () => {
+      const orders = [
+        createOrder({
+          transactions: [
+            { date: '2026-04-17', amount: 14.93, currency: 'USD' },
+            { date: '2026-04-20', amount: 61.01, currency: 'USD' },
+          ],
+          items: [
+            {
+              title: 'Product 1',
+              asin: 'B000000001',
+              quantity: 1,
+              price: 14.93,
+              discount: 0,
+              itemUrl: 'https://amazon.de/dp/B000000001',
+            },
+            {
+              title: 'Product 2',
+              asin: 'B000000002',
+              quantity: 1,
+              price: 61.01,
+              discount: 0,
+              itemUrl: 'https://amazon.de/dp/B000000002',
+            },
+          ],
+        }),
+      ];
+      const csv = convertOrdersToCSV(orders, undefined, true);
+      const lines = csv.split('\n');
+
+      // First item row should have transaction data
+      expect(lines[1]).toContain('2026-04-17 | 2026-04-20');
+      expect(lines[1]).toContain('14.93 | 61.01');
+
+      // Second item row should have empty transaction columns
+      const secondRowCols = lines[2]!.split(',');
+      expect(secondRowCols[14]).toBe('');
+      expect(secondRowCols[15]).toBe('');
+    });
+
+    it('should leave transaction columns empty when order has no transactions', () => {
+      const orders = [createOrder({ transactions: [] })];
+      const csv = convertOrdersToCSV(orders, undefined, true);
+      const lines = csv.split('\n');
+      const dataCols = lines[1]!.split(',');
+      expect(dataCols[14]).toBe('');
+      expect(dataCols[15]).toBe('');
+    });
+
+    it('should leave transaction columns empty when order.transactions is undefined', () => {
+      const orders = [createOrder()]; // no transactions field
+      const csv = convertOrdersToCSV(orders, undefined, true);
+      const lines = csv.split('\n');
+      const dataCols = lines[1]!.split(',');
+      expect(dataCols[14]).toBe('');
+      expect(dataCols[15]).toBe('');
+    });
+
+    it('should populate transaction columns for order with no items', () => {
+      const orders = [
+        createOrder({
+          items: [],
+          transactions: [{ date: '2026-04-17', amount: 75.94, currency: 'USD' }],
+        }),
+      ];
+      const csv = convertOrdersToCSV(orders, undefined, true);
+      const lines = csv.split('\n');
+      expect(lines[1]).toContain('2026-04-17');
+      expect(lines[1]).toContain('75.94');
+    });
+  });
 });

--- a/tests/priceUtils.test.ts
+++ b/tests/priceUtils.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { parsePrice, detectCurrency, extractPriceFromText } from '../src/utils/priceUtils';
+import {
+  parsePrice,
+  detectCurrency,
+  extractPriceFromText,
+  extractSignedPriceFromText,
+} from '../src/utils/priceUtils';
 
 describe('parsePrice', () => {
   describe('European format', () => {
@@ -138,5 +143,65 @@ describe('extractPriceFromText', () => {
     it('should not match zero amounts', () => {
       expect(extractPriceFromText('Total: €0,00')).toBeNull();
     });
+  });
+});
+
+describe('extractSignedPriceFromText', () => {
+  it('returns positive amount for normal charge text', () => {
+    expect(extractSignedPriceFromText('$29.99 charged on June 5, 2026')).toEqual({
+      amount: 29.99,
+      currency: 'USD',
+    });
+  });
+
+  it('returns negative amount when text starts with minus sign before $', () => {
+    expect(extractSignedPriceFromText('-$14.93')).toEqual({ amount: -14.93, currency: 'USD' });
+  });
+
+  it('returns negative amount for minus sign before EUR symbol', () => {
+    expect(extractSignedPriceFromText('-€12,50')).toEqual({ amount: -12.5, currency: 'EUR' });
+  });
+
+  it('returns negative amount when "refund" keyword present', () => {
+    expect(extractSignedPriceFromText('Refund: $14.93')).toEqual({
+      amount: -14.93,
+      currency: 'USD',
+    });
+  });
+
+  it('returns negative amount for "refunded" keyword', () => {
+    expect(extractSignedPriceFromText('$29.99 refunded on June 10, 2026')).toEqual({
+      amount: -29.99,
+      currency: 'USD',
+    });
+  });
+
+  it('returns negative amount for German refund keyword (Rückerstattung)', () => {
+    expect(extractSignedPriceFromText('Rückerstattung €12,50')).toEqual({
+      amount: -12.5,
+      currency: 'EUR',
+    });
+  });
+
+  it('returns negative amount for German Gutschrift keyword', () => {
+    expect(extractSignedPriceFromText('Gutschrift: €5,00')).toEqual({
+      amount: -5.0,
+      currency: 'EUR',
+    });
+  });
+
+  it('returns negative amount for French remboursé keyword', () => {
+    expect(extractSignedPriceFromText('Remboursé: €29,99')).toEqual({
+      amount: -29.99,
+      currency: 'EUR',
+    });
+  });
+
+  it('returns null for zero amounts', () => {
+    expect(extractSignedPriceFromText('Refund: $0.00')).toBeNull();
+  });
+
+  it('returns null when no price is found', () => {
+    expect(extractSignedPriceFromText('No price here')).toBeNull();
   });
 });

--- a/tests/transactionUtils.test.ts
+++ b/tests/transactionUtils.test.ts
@@ -1,0 +1,194 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import {
+  buildTransactionUrl,
+  formatTransactionDatesForCSV,
+  formatTransactionAmountsForCSV,
+  parseTransactionsFromCPEPage,
+} from '../src/utils/transactionUtils';
+import type { Transaction } from '../src/types';
+
+describe('buildTransactionUrl', () => {
+  it('should build the correct URL for amazon.com', () => {
+    const url = buildTransactionUrl('https://www.amazon.com', '112-1234567-1234567');
+    expect(url).toBe(
+      'https://www.amazon.com/cpe/yourpayments/transactions?transactionTag=112-1234567-1234567'
+    );
+  });
+
+  it('should build the correct URL for amazon.de', () => {
+    const url = buildTransactionUrl('https://www.amazon.de', '123-4567890-1234567');
+    expect(url).toBe(
+      'https://www.amazon.de/cpe/yourpayments/transactions?transactionTag=123-4567890-1234567'
+    );
+  });
+
+  it('should build the correct URL for amazon.co.uk', () => {
+    const url = buildTransactionUrl('https://www.amazon.co.uk', '026-9876543-2109876');
+    expect(url).toBe(
+      'https://www.amazon.co.uk/cpe/yourpayments/transactions?transactionTag=026-9876543-2109876'
+    );
+  });
+
+  it('should URL-encode the order ID', () => {
+    const url = buildTransactionUrl('https://www.amazon.com', '112-1234567-1234567');
+    expect(url).toContain('transactionTag=112-1234567-1234567');
+  });
+
+  it('should use the provided origin verbatim', () => {
+    const url = buildTransactionUrl('https://www.amazon.fr', '111-2222222-3333333');
+    expect(url.startsWith('https://www.amazon.fr')).toBe(true);
+  });
+});
+
+describe('formatTransactionDatesForCSV', () => {
+  it('should return empty string for no transactions', () => {
+    expect(formatTransactionDatesForCSV([])).toBe('');
+  });
+
+  it('should return the date for a single transaction', () => {
+    const transactions: Transaction[] = [{ date: '2026-04-17', amount: 14.93, currency: 'USD' }];
+    expect(formatTransactionDatesForCSV(transactions)).toBe('2026-04-17');
+  });
+
+  it('should join multiple dates with " | "', () => {
+    const transactions: Transaction[] = [
+      { date: '2026-04-17', amount: 14.93, currency: 'USD' },
+      { date: '2026-04-20', amount: 61.01, currency: 'USD' },
+    ];
+    expect(formatTransactionDatesForCSV(transactions)).toBe('2026-04-17 | 2026-04-20');
+  });
+
+  it('should handle three transactions', () => {
+    const transactions: Transaction[] = [
+      { date: '2026-01-01', amount: 10.0, currency: 'EUR' },
+      { date: '2026-01-05', amount: 20.0, currency: 'EUR' },
+      { date: '2026-01-10', amount: 5.5, currency: 'EUR' },
+    ];
+    expect(formatTransactionDatesForCSV(transactions)).toBe('2026-01-01 | 2026-01-05 | 2026-01-10');
+  });
+});
+
+describe('formatTransactionAmountsForCSV', () => {
+  it('should return empty string for no transactions', () => {
+    expect(formatTransactionAmountsForCSV([])).toBe('');
+  });
+
+  it('should return the amount as a string for a single transaction', () => {
+    const transactions: Transaction[] = [{ date: '2026-04-17', amount: 14.93, currency: 'USD' }];
+    expect(formatTransactionAmountsForCSV(transactions)).toBe('14.93');
+  });
+
+  it('should join multiple amounts with " | "', () => {
+    const transactions: Transaction[] = [
+      { date: '2026-04-17', amount: 14.93, currency: 'USD' },
+      { date: '2026-04-20', amount: 61.01, currency: 'USD' },
+    ];
+    expect(formatTransactionAmountsForCSV(transactions)).toBe('14.93 | 61.01');
+  });
+
+  it('should handle integer amounts', () => {
+    const transactions: Transaction[] = [
+      { date: '2026-01-01', amount: 10, currency: 'EUR' },
+      { date: '2026-01-05', amount: 20, currency: 'EUR' },
+    ];
+    expect(formatTransactionAmountsForCSV(transactions)).toBe('10 | 20');
+  });
+
+  it('should handle three transactions', () => {
+    const transactions: Transaction[] = [
+      { date: '2026-01-01', amount: 10.0, currency: 'EUR' },
+      { date: '2026-01-05', amount: 20.5, currency: 'EUR' },
+      { date: '2026-01-10', amount: 5.99, currency: 'EUR' },
+    ];
+    expect(formatTransactionAmountsForCSV(transactions)).toBe('10 | 20.5 | 5.99');
+  });
+});
+
+// Minimal CPE page HTML matching Amazon's confirmed server-rendered structure
+function makeCPEHtml(entries: { date: string; amount: string }[]): string {
+  const groups = entries
+    .map(
+      ({ date, amount }) => `
+    <div class="a-box-group">
+      <div class="a-box apx-transactions-sleeve-header-container">
+        <span class="a-size-base a-text-bold">Completed</span>
+      </div>
+      <div class="a-box">
+        <div class="apx-transaction-date-container"><span>${date}</span></div>
+        <div class="apx-transactions-line-item-component-container">
+          <div class="a-column a-span3 a-text-right a-span-last">
+            <span class="a-size-base-plus a-text-bold">${amount}</span>
+          </div>
+        </div>
+      </div>
+    </div>`
+    )
+    .join('');
+  return `<!DOCTYPE html><html><body>${groups}</body></html>`;
+}
+
+describe('parseTransactionsFromCPEPage', () => {
+  it('parses a USD charge (negative in Amazon UI → positive in export)', () => {
+    const html = makeCPEHtml([{ date: 'June 6, 2026', amount: '-$51.12' }]);
+    const result = parseTransactionsFromCPEPage(html);
+    expect(result).toEqual([{ date: '2026-06-06', amount: 51.12, currency: 'USD' }]);
+  });
+
+  it('parses a USD refund (positive in Amazon UI → negative in export)', () => {
+    const html = makeCPEHtml([{ date: 'June 10, 2026', amount: '$10.00' }]);
+    const result = parseTransactionsFromCPEPage(html);
+    expect(result).toEqual([{ date: '2026-06-10', amount: -10.0, currency: 'USD' }]);
+  });
+
+  it('parses a EUR charge with European decimal format', () => {
+    const html = makeCPEHtml([{ date: 'June 6, 2026', amount: '-€52,95' }]);
+    const result = parseTransactionsFromCPEPage(html);
+    expect(result).toEqual([{ date: '2026-06-06', amount: 52.95, currency: 'EUR' }]);
+  });
+
+  it('parses multiple transactions from one page', () => {
+    const html = makeCPEHtml([
+      { date: 'June 6, 2026', amount: '-$51.12' },
+      { date: 'June 1, 2026', amount: '-$14.93' },
+    ]);
+    const result = parseTransactionsFromCPEPage(html);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({ date: '2026-06-06', amount: 51.12, currency: 'USD' });
+    expect(result[1]).toEqual({ date: '2026-06-01', amount: 14.93, currency: 'USD' });
+  });
+
+  it('deduplicates identical date+amount entries', () => {
+    const html = makeCPEHtml([
+      { date: 'June 6, 2026', amount: '-$51.12' },
+      { date: 'June 6, 2026', amount: '-$51.12' },
+    ]);
+    const result = parseTransactionsFromCPEPage(html);
+    expect(result).toHaveLength(1);
+  });
+
+  it('returns empty array when page has no transaction groups', () => {
+    const html = '<!DOCTYPE html><html><body><div>No transactions here</div></body></html>';
+    const result = parseTransactionsFromCPEPage(html);
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array when transaction group has no recognizable date', () => {
+    const html = `<!DOCTYPE html><html><body>
+      <div class="a-box-group">
+        <div class="apx-transaction-date-container"><span>not a date</span></div>
+        <div class="a-column a-span3 a-text-right a-span-last">
+          <span class="a-size-base-plus a-text-bold">-$51.12</span>
+        </div>
+      </div>
+    </body></html>`;
+    const result = parseTransactionsFromCPEPage(html);
+    expect(result).toEqual([]);
+  });
+
+  it('uses the unicode minus sign (−) as a debit indicator', () => {
+    const html = makeCPEHtml([{ date: 'June 6, 2026', amount: '−$51.12' }]);
+    const result = parseTransactionsFromCPEPage(html);
+    expect(result).toEqual([{ date: '2026-06-06', amount: 51.12, currency: 'USD' }]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds an opt-in "Include transaction details" checkbox to the popup. When enabled, the exporter fetches each order's /cpe/yourpayments/transactions page (Amazon's server-rendered CPE page) to extract the actual charged amount and date — rather than the pre-tax subtotal on the order detail page.

Key changes:
- New Transaction type (date, amount, currency) added to Order
- Popup checkbox with browser.storage.local persistence
- CPE page parser using confirmed CSS selectors (.apx-transaction-date-container, .a-column.a-span3.a-text-right.a-span-last .a-size-base-plus.a-text-bold)
- Sign convention: Amazon shows charges as -$X.XX (debit), refunds as $X.XX (credit); we negate so exports read positive=paid, negative=refunded
- extractSignedPriceFromText utility handles explicit minus signs and refund keywords across EN/DE/FR/IT/ES locales
- CSV output gains Transaction Dates and Transaction Amounts columns
- Pagination fix: passedStartDate flag prevents stopping too early when a date-range export starts on a page with no matching orders
- 22 unit tests for transactionUtils (incl. parseTransactionsFromCPEPage via @vitest-environment jsdom); 10 new priceUtils tests for signed amounts
- jsdom added as dev dependency for browser-DOM test environment

## Related Issue

Closes #

## Maintainer Collaboration

- [x] I enabled **Allow edits from maintainers** on this PR.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation update
- [ ] Chore/maintenance

## Breaking Changes

- [ ] This PR introduces a breaking change.
- [ ] I documented migration or compatibility notes (if applicable).

## UI Changes

- [x] This PR includes UI changes.
- [x] I added screenshots or recordings for UI changes (if applicable).

<img width="330" height="481" alt="image" src="https://github.com/user-attachments/assets/678cfc3f-24d6-432a-8a56-e7f6422d7bf6" />


## How Was This Tested?

List the commands and/or manual checks you ran.

```bash
  npm run lint          # no errors
  npm run typecheck     # no errors
  npm run test          # 176 passed (2 pre-existing filterYearsByDateRange failures,
  unrelated)
  npm run format:check  # no issues
```

  Manual testing on amazon.com:
  - Loaded the extension on the order history page with "Include transaction details" checked
  - Verified the CSV export contains Transaction Dates and Transaction Amounts columns
  populated with correct data
  - Confirmed amounts match the actual charge (including tax) sourced from
  /cpe/yourpayments/transactions, not the pre-tax subtotal from the order detail page
  - Verified that unchecking the option produces output identical to the previous behavior

## Checklist

- [x] I verified the change locally.
- [x] I added or updated tests when behavior changed.
- [x] I updated documentation when needed.
- [x] I updated locale/messages or metadata when needed.
- [x] I confirmed no sensitive data was added.
