### PR TITLE
Add stop button to cancel in-progress exports and improve handling

### DIFF
--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -47,6 +47,10 @@
     "message": "Exportieren",
     "description": "Export button text"
   },
+  "stopExport": {
+    "message": "Export abbrechen",
+    "description": "Stop button text"
+  },
   "exporting": {
     "message": "Exportiere...",
     "description": "Text shown while exporting"
@@ -140,6 +144,10 @@
   "generatingFile": {
     "message": "Datei wird erstellt...",
     "description": "Progress message while generating file"
+  },
+  "exportStopped": {
+    "message": "Export vom Benutzer abgebrochen.",
+    "description": "Status message when export is stopped"
   },
   "exportComplete": {
     "message": "Fertig! $COUNT$ Bestellungen exportiert.",

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -47,6 +47,10 @@
     "message": "Export Orders",
     "description": "Export button text"
   },
+  "stopExport": {
+    "message": "Stop Export",
+    "description": "Stop button text"
+  },
   "exporting": {
     "message": "Exporting...",
     "description": "Text shown while exporting"
@@ -140,6 +144,10 @@
   "generatingFile": {
     "message": "Generating file...",
     "description": "Progress message while generating file"
+  },
+  "exportStopped": {
+    "message": "Export stopped by user.",
+    "description": "Status message when export is stopped"
   },
   "exportComplete": {
     "message": "Export complete! $COUNT$ orders exported.",

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -47,6 +47,10 @@
     "message": "Exportar pedidos",
     "description": "Export button text"
   },
+  "stopExport": {
+    "message": "Detener exportación",
+    "description": "Stop button text"
+  },
   "exporting": {
     "message": "Exportando...",
     "description": "Text shown while exporting"
@@ -140,6 +144,10 @@
   "generatingFile": {
     "message": "Generando archivo...",
     "description": "Progress message while generating file"
+  },
+  "exportStopped": {
+    "message": "Exportación detenida por el usuario.",
+    "description": "Status message when export is stopped"
   },
   "exportComplete": {
     "message": "¡Exportación completada! $COUNT$ pedidos exportados.",

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -47,6 +47,10 @@
     "message": "Exporter les commandes",
     "description": "Export button text"
   },
+  "stopExport": {
+    "message": "Arrêter l'exportation",
+    "description": "Stop button text"
+  },
   "exporting": {
     "message": "Exportation...",
     "description": "Text shown while exporting"
@@ -140,6 +144,10 @@
   "generatingFile": {
     "message": "Génération du fichier...",
     "description": "Progress message while generating file"
+  },
+  "exportStopped": {
+    "message": "Exportation arrêtée par l'utilisateur.",
+    "description": "Status message when export is stopped"
   },
   "exportComplete": {
     "message": "Exportation terminée ! $COUNT$ commandes exportées.",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,9 @@
+/**
+ * Shared constants for Order History Exporter for Amazon
+ */
+
+/** Key for the export state in sessionStorage */
+export const STORAGE_KEY = 'amazonExporter';
+
+/** Key for the stop-requested flag in browser.storage.session */
+export const STOP_FLAG_KEY = 'amazonExporterStopRequested';

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -26,6 +26,9 @@ import {
 
   const STORAGE_KEY = 'amazonExporter';
 
+  /** Flag set to true when the user requests a stop */
+  let stopRequested = false;
+
   /**
    * Get localized message from browser i18n API
    */
@@ -48,6 +51,12 @@ import {
     if (msg.action === 'getExportStatus') {
       const state = getExportState();
       return Promise.resolve(state ? { success: true, ...state } : { success: false });
+    }
+    if (msg.action === 'stopExport') {
+      stopRequested = true;
+      clearExportState();
+      updateProgress(0, getMessage('exportStopped'));
+      return Promise.resolve({ success: true });
     }
 
     return undefined;
@@ -162,6 +171,11 @@ import {
    * Continue an export after page navigation
    */
   function continueExport(state: ExportState): void {
+    // Check if stop was requested while away (e.g. between page navigations)
+    if (stopRequested || !getExportState()) {
+      return;
+    }
+
     const currentYear = state.yearsToProcess[state.currentYearIndex];
     const pageNum = String(Math.floor(state.currentStartIndex / 10) + 1);
     updateProgress(
@@ -176,6 +190,11 @@ import {
    * Scrape the current page and decide what to do next
    */
   function scrapeCurrentPageAndContinue(state: ExportState): void {
+    // Check if stop was requested mid-export
+    if (stopRequested || !getExportState()) {
+      return;
+    }
+
     const startDateObj = state.startDate ? new Date(state.startDate) : null;
     const endDateObj = state.endDate ? new Date(state.endDate) : null;
 
@@ -245,6 +264,12 @@ import {
 
     // Fetch item prices for multi-item orders
     await fetchOrderDetailsForPrices(state.collectedOrders);
+
+    // Check if stop was requested during price fetching
+    if (stopRequested || !getExportState()) {
+      clearExportState();
+      return;
+    }
 
     updateProgress(95, getMessage('generatingFile'));
 
@@ -665,6 +690,11 @@ import {
     console.log('[Amazon Exporter] Fetching details for', ordersNeedingDetails.length, 'orders');
 
     for (let i = 0; i < ordersNeedingDetails.length; i++) {
+      // Check if stop was requested during price fetching
+      if (stopRequested || !getExportState()) {
+        break;
+      }
+
       const order = ordersNeedingDetails[i];
       if (!order) continue;
 

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -106,12 +106,19 @@ import { STORAGE_KEY, STOP_FLAG_KEY } from '../constants';
   function checkExportState(): void {
     const run = (): void => {
       setTimeout(async () => {
-        // Check if stop was requested while the content script was unloaded
-        const stopFlag = await browser.storage.session.get(STOP_FLAG_KEY);
-        if (stopFlag[STOP_FLAG_KEY]) {
-          await browser.storage.session.remove(STOP_FLAG_KEY);
-          clearExportState();
-          return;
+        // Check if stop was requested while the content script was unloaded.
+        // Wrap in try-catch: if storage.session is unavailable (missing
+        // permission / unsupported browser), we still want the resume logic
+        // below to execute.
+        try {
+          const stopFlag = await browser.storage.session.get(STOP_FLAG_KEY);
+          if (stopFlag[STOP_FLAG_KEY]) {
+            await browser.storage.session.remove(STOP_FLAG_KEY);
+            clearExportState();
+            return;
+          }
+        } catch {
+          console.debug('[Amazon Exporter] Could not read stop flag from storage.session');
         }
 
         const state = getExportState();

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -20,14 +20,21 @@ import {
   parsePrice,
   parseOrderStatus,
 } from '../utils';
+import { STORAGE_KEY, STOP_FLAG_KEY } from '../constants';
 
 (function (): void {
   'use strict';
 
-  const STORAGE_KEY = 'amazonExporter';
-  const STOP_FLAG_KEY = 'amazonExporterStopRequested';
-
-  /** Flag set to true when the user requests a stop */
+  /**
+   * In-memory stop flag for the current page load.
+   *
+   * Because the content script is reloaded on every page navigation, this flag
+   * only survives within a single page.  For cross-navigation stop requests
+   * (i.e. the user clicks "Stop" while the content script is between pages) we
+   * also persist the flag to `browser.storage.session` under STOP_FLAG_KEY.
+   * `checkExportState` reads that persisted flag on the next page load, so the
+   * stop takes effect even when the direct message is lost.
+   */
   let stopRequested = false;
 
   /**

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -56,6 +56,8 @@ import {
       stopRequested = true;
       clearExportState();
       updateProgress(0, getMessage('exportStopped'));
+      // Notify popup via dedicated action so it doesn't rely on string comparison
+      browser.runtime.sendMessage({ action: 'exportStopped' }).catch(() => {});
       return Promise.resolve({ success: true });
     }
 
@@ -101,7 +103,15 @@ import {
     }
 
     // Additional delay to let Amazon's JS render
-    setTimeout(() => {
+    setTimeout(async () => {
+      // Check if stop was requested while the content script was unloaded
+      const stopFlag = await browser.storage.session.get('amazonExporterStopRequested');
+      if (stopFlag.amazonExporterStopRequested) {
+        await browser.storage.session.remove('amazonExporterStopRequested');
+        clearExportState();
+        return;
+      }
+
       const state = getExportState();
       if (state && state.inProgress) {
         console.log('[Amazon Exporter]', getMessage('resumingExport'), state);
@@ -114,6 +124,9 @@ import {
    * Start a new export
    */
   function startExport(options: ExportOptions): void {
+    // Reset stop flag for fresh export
+    stopRequested = false;
+
     const { format, startDate, endDate, exportAll } = options;
 
     // Get available years

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -25,6 +25,7 @@ import {
   'use strict';
 
   const STORAGE_KEY = 'amazonExporter';
+  const STOP_FLAG_KEY = 'amazonExporterStopRequested';
 
   /** Flag set to true when the user requests a stop */
   let stopRequested = false;
@@ -55,7 +56,6 @@ import {
     if (msg.action === 'stopExport') {
       stopRequested = true;
       clearExportState();
-      updateProgress(0, getMessage('exportStopped'));
       // Notify popup via dedicated action so it doesn't rely on string comparison
       browser.runtime.sendMessage({ action: 'exportStopped' }).catch(() => {});
       return Promise.resolve({ success: true });
@@ -105,9 +105,9 @@ import {
     // Additional delay to let Amazon's JS render
     setTimeout(async () => {
       // Check if stop was requested while the content script was unloaded
-      const stopFlag = await browser.storage.session.get('amazonExporterStopRequested');
-      if (stopFlag.amazonExporterStopRequested) {
-        await browser.storage.session.remove('amazonExporterStopRequested');
+      const stopFlag = await browser.storage.session.get(STOP_FLAG_KEY);
+      if (stopFlag[STOP_FLAG_KEY]) {
+        await browser.storage.session.remove(STOP_FLAG_KEY);
         clearExportState();
         return;
       }
@@ -278,9 +278,8 @@ import {
     // Fetch item prices for multi-item orders
     await fetchOrderDetailsForPrices(state.collectedOrders);
 
-    // Check if stop was requested during price fetching
+    // Check if stop was requested during price fetching (state already cleared by handler)
     if (stopRequested || !getExportState()) {
-      clearExportState();
       return;
     }
 

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -64,7 +64,10 @@ import { STORAGE_KEY, STOP_FLAG_KEY } from '../constants';
       stopRequested = true;
       clearExportState();
       // Notify popup via dedicated action so it doesn't rely on string comparison
-      browser.runtime.sendMessage({ action: 'exportStopped' }).catch(() => {});
+      browser.runtime.sendMessage({ action: 'exportStopped' }).catch(() => {
+        // Popup may not be open — not an error condition
+        console.debug('[Amazon Exporter] Popup not reachable for exportStopped notification');
+      });
       return Promise.resolve({ success: true });
     }
 
@@ -101,30 +104,30 @@ import { STORAGE_KEY, STOP_FLAG_KEY } from '../constants';
    * Check if we should continue an export after page navigation
    */
   function checkExportState(): void {
-    // Wait for page to be fully loaded
-    if (document.readyState !== 'complete') {
-      window.addEventListener('load', () => {
-        setTimeout(checkExportState, 500);
-      });
-      return;
+    const run = (): void => {
+      setTimeout(async () => {
+        // Check if stop was requested while the content script was unloaded
+        const stopFlag = await browser.storage.session.get(STOP_FLAG_KEY);
+        if (stopFlag[STOP_FLAG_KEY]) {
+          await browser.storage.session.remove(STOP_FLAG_KEY);
+          clearExportState();
+          return;
+        }
+
+        const state = getExportState();
+        if (state && state.inProgress) {
+          console.log('[Amazon Exporter]', getMessage('resumingExport'), state);
+          continueExport(state);
+        }
+      }, 1500);
+    };
+
+    // Wait for page to be fully loaded, then add delay for Amazon's JS to render
+    if (document.readyState === 'complete') {
+      run();
+    } else {
+      window.addEventListener('load', run, { once: true });
     }
-
-    // Additional delay to let Amazon's JS render
-    setTimeout(async () => {
-      // Check if stop was requested while the content script was unloaded
-      const stopFlag = await browser.storage.session.get(STOP_FLAG_KEY);
-      if (stopFlag[STOP_FLAG_KEY]) {
-        await browser.storage.session.remove(STOP_FLAG_KEY);
-        clearExportState();
-        return;
-      }
-
-      const state = getExportState();
-      if (state && state.inProgress) {
-        console.log('[Amazon Exporter]', getMessage('resumingExport'), state);
-        continueExport(state);
-      }
-    }, 1500);
   }
 
   /**

--- a/src/manifest.chrome.json
+++ b/src/manifest.chrome.json
@@ -9,7 +9,7 @@
     "96": "icons/icon-96.png",
     "128": "icons/icon-128.png"
   },
-  "permissions": ["activeTab", "downloads"],
+  "permissions": ["activeTab", "downloads", "storage"],
   "host_permissions": [
     "*://*.amazon.com/*",
     "*://*.amazon.co.uk/*",

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -11,6 +11,7 @@
   "permissions": [
     "activeTab",
     "downloads",
+    "storage",
     "*://*.amazon.com/*",
     "*://*.amazon.co.uk/*",
     "*://*.amazon.de/*",

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -164,27 +164,6 @@ header h1 {
   text-decoration: underline;
 }
 
-.btn-loading {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.spinner {
-  width: 14px;
-  height: 14px;
-  border: 2px solid #333;
-  border-top-color: transparent;
-  border-radius: 50%;
-  animation: spin 0.8s linear infinite;
-}
-
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
-}
-
 .progress-bar {
   height: 8px;
   background: #e0e0e0;

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -137,6 +137,22 @@ header h1 {
   cursor: not-allowed;
 }
 
+.btn-stop {
+  width: 100%;
+  background: #dc3545;
+  border: 1px solid #bd2130;
+  color: #fff;
+}
+
+.btn-stop:hover:not(:disabled) {
+  background: #c82333;
+}
+
+.btn-stop:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 .btn-link {
   background: none;
   color: #0066c0;

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -69,11 +69,8 @@
         </div>
 
         <section class="section">
-          <button id="exportBtn" class="btn btn-primary">
-            <span class="btn-text" data-i18n="exportOrders">Export Orders</span>
-            <span class="btn-loading hidden">
-              <span class="spinner"></span> <span data-i18n="exporting">Exporting...</span>
-            </span>
+          <button id="exportBtn" class="btn btn-primary" data-i18n="exportOrders">
+            Export Orders
           </button>
           <button id="stopBtn" class="btn btn-stop hidden" data-i18n="stopExport">
             Stop Export

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -75,6 +75,9 @@
               <span class="spinner"></span> <span data-i18n="exporting">Exporting...</span>
             </span>
           </button>
+          <button id="stopBtn" class="btn btn-stop hidden" data-i18n="stopExport">
+            Stop Export
+          </button>
         </section>
 
         <div id="progress-section" class="section hidden">

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -161,7 +161,11 @@ document.addEventListener('DOMContentLoaded', async () => {
     } catch {
       // Content script may be between page loads — persist stop flag so the
       // next page load can detect it and abort the auto-resume.
-      await browser.storage.session.set({ [STOP_FLAG_KEY]: true });
+      try {
+        await browser.storage.session.set({ [STOP_FLAG_KEY]: true });
+      } catch {
+        console.debug('[Amazon Exporter] Could not persist stop flag to storage.session');
+      }
     }
 
     // Fallback path: content script was unreachable or tab had no id.

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -165,37 +165,43 @@ document.addEventListener('DOMContentLoaded', async () => {
         await browser.tabs.sendMessage(tab.id, { action: 'stopExport' });
       }
     } catch {
-      // Content script may be between page loads; clearing state covers this case
+      // Content script may be between page loads — persist stop flag so the
+      // next page load can detect it and abort the auto-resume.
+      await browser.storage.session.set({ amazonExporterStopRequested: true });
     }
 
     // Restore UI
+    resetUI();
+    showStatus(getMessage('exportStopped'), 'info');
+  });
+
+  /**
+   * Restore the popup UI to its idle state (settings + export button visible)
+   */
+  function resetUI(): void {
     settingsSection.classList.remove('hidden');
     exportBtn.classList.remove('hidden');
     stopBtn.classList.add('hidden');
     hideProgress();
-    showStatus(getMessage('exportStopped'), 'info');
-  });
+  }
 
   // Listen for progress updates from content script
   browser.runtime.onMessage.addListener((message: unknown) => {
     const msg = message as { action: string; data?: ProgressData };
+
+    if (msg.action === 'exportStopped') {
+      resetUI();
+      showStatus(getMessage('exportStopped'), 'info');
+      return;
+    }
+
     if (msg.action === 'updateProgress' && msg.data) {
       showProgress(msg.data.percent, msg.data.message);
 
       // If complete, show success message and restore UI
       if (msg.data.percent >= 100) {
-        settingsSection.classList.remove('hidden');
-        exportBtn.classList.remove('hidden');
-        stopBtn.classList.add('hidden');
+        resetUI();
         showStatus(msg.data.message, 'success');
-      }
-
-      // If stopped, restore UI
-      if (msg.data.message === getMessage('exportStopped')) {
-        settingsSection.classList.remove('hidden');
-        exportBtn.classList.remove('hidden');
-        stopBtn.classList.add('hidden');
-        hideProgress();
       }
     }
   });
@@ -231,5 +237,4 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   // Suppress unused function warnings
   void setLoading;
-  void hideProgress;
 });

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -7,6 +7,8 @@ import browser from 'webextension-polyfill';
 import type { ExportOptions, ProgressData } from '../types';
 import { isAmazonOrderHistoryPage } from '../utils';
 
+const STOP_FLAG_KEY = 'amazonExporterStopRequested';
+
 /**
  * Get localized message from browser i18n API
  */
@@ -167,7 +169,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     } catch {
       // Content script may be between page loads — persist stop flag so the
       // next page load can detect it and abort the auto-resume.
-      await browser.storage.session.set({ amazonExporterStopRequested: true });
+      await browser.storage.session.set({ [STOP_FLAG_KEY]: true });
     }
 
     // Restore UI
@@ -182,6 +184,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     settingsSection.classList.remove('hidden');
     exportBtn.classList.remove('hidden');
     stopBtn.classList.add('hidden');
+    stopBtn.disabled = false;
     hideProgress();
   }
 

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -35,6 +35,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   const notAmazonEl = document.getElementById('not-amazon') as HTMLElement;
   const mainContentEl = document.getElementById('main-content') as HTMLElement;
   const exportBtn = document.getElementById('exportBtn') as HTMLButtonElement;
+  const stopBtn = document.getElementById('stopBtn') as HTMLButtonElement;
   const btnText = exportBtn.querySelector('.btn-text') as HTMLElement;
   const btnLoading = exportBtn.querySelector('.btn-loading') as HTMLElement;
   const progressSection = document.getElementById('progress-section') as HTMLElement;
@@ -104,9 +105,10 @@ document.addEventListener('DOMContentLoaded', async () => {
       }
     }
 
-    // Start export - hide settings and show progress
+    // Start export - hide settings, show progress and stop button
     settingsSection.classList.add('hidden');
     exportBtn.classList.add('hidden');
+    stopBtn.classList.remove('hidden');
     showProgress(0, getMessage('exportStartedMessage'));
     showStatus(getMessage('exportStartedStatus'), 'success');
 
@@ -114,6 +116,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       if (!currentTab?.id) {
         settingsSection.classList.remove('hidden');
         exportBtn.classList.remove('hidden');
+        stopBtn.classList.add('hidden');
         hideProgress();
         showStatus(getMessage('errorGetTab'), 'error');
         return;
@@ -137,6 +140,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       } else {
         settingsSection.classList.remove('hidden');
         exportBtn.classList.remove('hidden');
+        stopBtn.classList.add('hidden');
         hideProgress();
         showStatus(response.error || getMessage('exportFailedGeneric'), 'error');
       }
@@ -144,9 +148,32 @@ document.addEventListener('DOMContentLoaded', async () => {
       console.error('Export error:', error);
       settingsSection.classList.remove('hidden');
       exportBtn.classList.remove('hidden');
+      stopBtn.classList.add('hidden');
       hideProgress();
       showStatus(getMessage('exportFailedRefresh'), 'error');
     }
+  });
+
+  // Handle stop button click
+  stopBtn.addEventListener('click', async () => {
+    stopBtn.disabled = true;
+
+    try {
+      const tabs = await browser.tabs.query({ active: true, currentWindow: true });
+      const tab = tabs[0];
+      if (tab?.id) {
+        await browser.tabs.sendMessage(tab.id, { action: 'stopExport' });
+      }
+    } catch {
+      // Content script may be between page loads; clearing state covers this case
+    }
+
+    // Restore UI
+    settingsSection.classList.remove('hidden');
+    exportBtn.classList.remove('hidden');
+    stopBtn.classList.add('hidden');
+    hideProgress();
+    showStatus(getMessage('exportStopped'), 'info');
   });
 
   // Listen for progress updates from content script
@@ -159,7 +186,16 @@ document.addEventListener('DOMContentLoaded', async () => {
       if (msg.data.percent >= 100) {
         settingsSection.classList.remove('hidden');
         exportBtn.classList.remove('hidden');
+        stopBtn.classList.add('hidden');
         showStatus(msg.data.message, 'success');
+      }
+
+      // If stopped, restore UI
+      if (msg.data.message === getMessage('exportStopped')) {
+        settingsSection.classList.remove('hidden');
+        exportBtn.classList.remove('hidden');
+        stopBtn.classList.add('hidden');
+        hideProgress();
       }
     }
   });

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -108,6 +108,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     settingsSection.classList.add('hidden');
     exportBtn.classList.add('hidden');
     stopBtn.classList.remove('hidden');
+    stopBtn.disabled = false;
     showProgress(0, getMessage('exportStartedMessage'));
     showStatus(getMessage('exportStartedStatus'), 'success');
 

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -114,10 +114,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     try {
       if (!currentTab?.id) {
-        settingsSection.classList.remove('hidden');
-        exportBtn.classList.remove('hidden');
-        stopBtn.classList.add('hidden');
-        hideProgress();
+        resetUI();
         showStatus(getMessage('errorGetTab'), 'error');
         return;
       }
@@ -138,18 +135,12 @@ document.addEventListener('DOMContentLoaded', async () => {
       if (response.success) {
         showStatus(getMessage('exportInitiatedStatus'), 'success');
       } else {
-        settingsSection.classList.remove('hidden');
-        exportBtn.classList.remove('hidden');
-        stopBtn.classList.add('hidden');
-        hideProgress();
+        resetUI();
         showStatus(response.error || getMessage('exportFailedGeneric'), 'error');
       }
     } catch (error) {
       console.error('Export error:', error);
-      settingsSection.classList.remove('hidden');
-      exportBtn.classList.remove('hidden');
-      stopBtn.classList.add('hidden');
-      hideProgress();
+      resetUI();
       showStatus(getMessage('exportFailedRefresh'), 'error');
     }
   });
@@ -164,9 +155,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       if (tab?.id) {
         await browser.tabs.sendMessage(tab.id, { action: 'stopExport' });
         // Content script is reachable — it will send back an exportStopped
-        // message that triggers the UI reset in the listener below.
-        // Show immediate feedback that the stop was requested:
-        showStatus(getMessage('exportStopped'), 'info');
+        // message that triggers the UI reset and status in the listener below.
         return;
       }
     } catch {
@@ -188,7 +177,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     settingsSection.classList.remove('hidden');
     exportBtn.classList.remove('hidden');
     stopBtn.classList.add('hidden');
-    stopBtn.disabled = false;
     hideProgress();
   }
 

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -6,8 +6,7 @@
 import browser from 'webextension-polyfill';
 import type { ExportOptions, ProgressData } from '../types';
 import { isAmazonOrderHistoryPage } from '../utils';
-
-const STOP_FLAG_KEY = 'amazonExporterStopRequested';
+import { STOP_FLAG_KEY } from '../constants';
 
 /**
  * Get localized message from browser i18n API
@@ -38,8 +37,6 @@ document.addEventListener('DOMContentLoaded', async () => {
   const mainContentEl = document.getElementById('main-content') as HTMLElement;
   const exportBtn = document.getElementById('exportBtn') as HTMLButtonElement;
   const stopBtn = document.getElementById('stopBtn') as HTMLButtonElement;
-  const btnText = exportBtn.querySelector('.btn-text') as HTMLElement;
-  const btnLoading = exportBtn.querySelector('.btn-loading') as HTMLElement;
   const progressSection = document.getElementById('progress-section') as HTMLElement;
   const progressFill = document.getElementById('progressFill') as HTMLElement;
   const progressText = document.getElementById('progressText') as HTMLElement;
@@ -165,6 +162,11 @@ document.addEventListener('DOMContentLoaded', async () => {
       const tab = tabs[0];
       if (tab?.id) {
         await browser.tabs.sendMessage(tab.id, { action: 'stopExport' });
+        // Content script is reachable — it will send back an exportStopped
+        // message that triggers the UI reset in the listener below.
+        // Show immediate feedback that the stop was requested:
+        showStatus(getMessage('exportStopped'), 'info');
+        return;
       }
     } catch {
       // Content script may be between page loads — persist stop flag so the
@@ -172,7 +174,8 @@ document.addEventListener('DOMContentLoaded', async () => {
       await browser.storage.session.set({ [STOP_FLAG_KEY]: true });
     }
 
-    // Restore UI
+    // Fallback path: content script was unreachable or tab had no id.
+    // The exportStopped message won't arrive, so reset the UI directly.
     resetUI();
     showStatus(getMessage('exportStopped'), 'info');
   });
@@ -209,12 +212,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
   });
 
-  function setLoading(loading: boolean): void {
-    exportBtn.disabled = loading;
-    btnText.classList.toggle('hidden', loading);
-    btnLoading.classList.toggle('hidden', !loading);
-  }
-
   function showProgress(percent: number, text: string): void {
     progressSection.classList.remove('hidden');
     progressFill.style.width = `${percent}%`;
@@ -230,14 +227,11 @@ document.addEventListener('DOMContentLoaded', async () => {
     statusMessage.className = `status-message ${type}`;
     statusMessage.classList.remove('hidden');
 
-    // Auto-hide success messages after 5 seconds
-    if (type === 'success') {
+    // Auto-hide success and info messages after 5 seconds
+    if (type === 'success' || type === 'info') {
       setTimeout(() => {
         statusMessage.classList.add('hidden');
       }, 5000);
     }
   }
-
-  // Suppress unused function warnings
-  void setLoading;
 });


### PR DESCRIPTION
This pull request adds a "Stop Export" feature to the Amazon Order History Exporter extension, allowing users to cancel an export in progress. It introduces new UI elements and logic to handle stopping exports, updates localization files for multiple languages, and cleans up the popup UI and related code. The most important changes are detailed below.

**New Stop Export Functionality**

* Added a "Stop Export" button to the popup UI (`popup.html`, `popup.css`, `popup.ts`) that lets users cancel an ongoing export. When pressed, it disables the button, notifies the content script, and resets the UI appropriately. [[1]](diffhunk://#diff-231bee292e0d2bb746eaef0fdd73140bf55c19d3f51789255643cb37d7ffe2e5L72-R76) [[2]](diffhunk://#diff-84de4f7ad44fd62f01b23dde0a7a309d1bf17f94384c2708f548552558cce330R140-R155) [[3]](diffhunk://#diff-ec0e05f2c4ee2c449b0b6abb19f3691b355bb0fd512a9266cb652451b35b0bedL38-R39) [[4]](diffhunk://#diff-ec0e05f2c4ee2c449b0b6abb19f3691b355bb0fd512a9266cb652451b35b0bedL107-R117) [[5]](diffhunk://#diff-ec0e05f2c4ee2c449b0b6abb19f3691b355bb0fd512a9266cb652451b35b0bedL138-L172)
* Implemented logic in the content script to handle stop requests, including an in-memory flag and a persistent flag in `browser.storage.session` to support stopping across page navigations. The export process checks this flag at various steps and aborts if set. [[1]](diffhunk://#diff-919634fc950d04e462ab81cbe737579cad7fa55c6f648932be87e11e43955c4fR23-R38) [[2]](diffhunk://#diff-919634fc950d04e462ab81cbe737579cad7fa55c6f648932be87e11e43955c4fR63-R72) [[3]](diffhunk://#diff-919634fc950d04e462ab81cbe737579cad7fa55c6f648932be87e11e43955c4fL86-R139) [[4]](diffhunk://#diff-919634fc950d04e462ab81cbe737579cad7fa55c6f648932be87e11e43955c4fR197-R201) [[5]](diffhunk://#diff-919634fc950d04e462ab81cbe737579cad7fa55c6f648932be87e11e43955c4fR216-R220) [[6]](diffhunk://#diff-919634fc950d04e462ab81cbe737579cad7fa55c6f648932be87e11e43955c4fR291-R295) [[7]](diffhunk://#diff-919634fc950d04e462ab81cbe737579cad7fa55c6f648932be87e11e43955c4fR715-R719) [[8]](diffhunk://#diff-8fa4b52909f895e8cda060d2035234e0a42ca2c7d3f8f8de1b35a056537bf199R1-R9)

**Localization Updates**

* Added new localized strings for "Stop Export" and "Export stopped by user" messages in English, German, French, and Spanish locale files. [[1]](diffhunk://#diff-a92a5a80239a5d0041533d117096d8a136752c0ab64cd397b0e7e9ad9cb04412R50-R53) [[2]](diffhunk://#diff-a92a5a80239a5d0041533d117096d8a136752c0ab64cd397b0e7e9ad9cb04412R148-R151) [[3]](diffhunk://#diff-342a314b13e0208ffe5e050db6f61811932513814d78562f8386d1de66bdc9cbR50-R53) [[4]](diffhunk://#diff-342a314b13e0208ffe5e050db6f61811932513814d78562f8386d1de66bdc9cbR148-R151) [[5]](diffhunk://#diff-b1e4cb45cb3a29e085d43781bbc62ddc48e9a6a9d759f543d5c6ea1a1c927177R50-R53) [[6]](diffhunk://#diff-b1e4cb45cb3a29e085d43781bbc62ddc48e9a6a9d759f543d5c6ea1a1c927177R148-R151) [[7]](diffhunk://#diff-a9281dcceec4e479c9cb58f6b86b49604c309c2f3cbc27bf624ae2fdaf57a018R50-R53) [[8]](diffhunk://#diff-a9281dcceec4e479c9cb58f6b86b49604c309c2f3cbc27bf624ae2fdaf57a018R148-R151)

**UI and Code Cleanup**

* Refactored the popup UI to use the new stop button and simplified the loading/progress indicator logic. Removed unused spinner/loading code from the CSS and HTML. [[1]](diffhunk://#diff-231bee292e0d2bb746eaef0fdd73140bf55c19d3f51789255643cb37d7ffe2e5L72-R76) [[2]](diffhunk://#diff-84de4f7ad44fd62f01b23dde0a7a309d1bf17f94384c2708f548552558cce330L151-L171) [[3]](diffhunk://#diff-ec0e05f2c4ee2c449b0b6abb19f3691b355bb0fd512a9266cb652451b35b0bedL188-L198)

**Shared Constants**

* Introduced a new `constants.ts` file to centralize storage key definitions for use across content and popup scripts. [[1]](diffhunk://#diff-8fa4b52909f895e8cda060d2035234e0a42ca2c7d3f8f8de1b35a056537bf199R1-R9) [[2]](diffhunk://#diff-919634fc950d04e462ab81cbe737579cad7fa55c6f648932be87e11e43955c4fR23-R38) [[3]](diffhunk://#diff-ec0e05f2c4ee2c449b0b6abb19f3691b355bb0fd512a9266cb652451b35b0bedR9)

**Robustness Improvements**

* Ensured that stop requests are respected even if the content script is reloaded or the popup is closed, by persisting the stop flag and checking it on page load and at key export steps. [[1]](diffhunk://#diff-919634fc950d04e462ab81cbe737579cad7fa55c6f648932be87e11e43955c4fL86-R139) [[2]](diffhunk://#diff-919634fc950d04e462ab81cbe737579cad7fa55c6f648932be87e11e43955c4fR197-R201) [[3]](diffhunk://#diff-919634fc950d04e462ab81cbe737579cad7fa55c6f648932be87e11e43955c4fR216-R220) [[4]](diffhunk://#diff-919634fc950d04e462ab81cbe737579cad7fa55c6f648932be87e11e43955c4fR291-R295) [[5]](diffhunk://#diff-919634fc950d04e462ab81cbe737579cad7fa55c6f648932be87e11e43955c4fR715-R719) [[6]](diffhunk://#diff-ec0e05f2c4ee2c449b0b6abb19f3691b355bb0fd512a9266cb652451b35b0bedL138-L172)

These changes together provide a more user-friendly export experience, allowing users to cancel exports reliably at any point.