### PR TITLE
feat(content): extract shipping recipient (name + address) from order cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,11 @@ The data model for each order includes the following fields:
             "amount": "number"
         }
     ],
-    "totalSavings": "number"
+    "totalSavings": "number",
+    "recipientName": "string (shipping recipient's name)",
+    "recipientStreet": "string (street lines joined by commas; may be empty)",
+    "recipientCityPostal": "string (city and postal code line; may be empty)",
+    "recipientCountry": "string (may be empty)"
 }
 ```
 
@@ -141,6 +145,10 @@ The CSV export creates multiple rows for orders with multiple items. Columns:
 | Promotions | Applied promotions |
 | Item URL | Link to product page |
 | Details URL | Link to order details |
+| Recipient Name | Shipping recipient's name (on the first item row only) |
+| Recipient Street | Shipping street address, multi-line joined by commas (on the first item row only) |
+| Recipient City / Postal | Shipping city and postal code line (on the first item row only) |
+| Recipient Country | Shipping country (on the first item row only) |
 
 ---
 

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -226,5 +226,21 @@
   "csvHeaderDetailsUrl": {
     "message": "Details-Link",
     "description": "CSV header for details URL"
+  },
+  "csvHeaderRecipientName": {
+    "message": "Empfängername",
+    "description": "CSV header for the shipping recipient's name"
+  },
+  "csvHeaderRecipientStreet": {
+    "message": "Empfängeradresse",
+    "description": "CSV header for the shipping recipient's street address (may include multiple lines joined by commas)"
+  },
+  "csvHeaderRecipientCityPostal": {
+    "message": "Stadt / PLZ des Empfängers",
+    "description": "CSV header for the shipping recipient's city and postal code line"
+  },
+  "csvHeaderRecipientCountry": {
+    "message": "Empfängerland",
+    "description": "CSV header for the shipping recipient's country"
   }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -226,5 +226,21 @@
   "csvHeaderDetailsUrl": {
     "message": "Details URL",
     "description": "CSV header for details URL"
+  },
+  "csvHeaderRecipientName": {
+    "message": "Recipient Name",
+    "description": "CSV header for the shipping recipient's name"
+  },
+  "csvHeaderRecipientStreet": {
+    "message": "Recipient Street",
+    "description": "CSV header for the shipping recipient's street address (may include multiple lines joined by commas)"
+  },
+  "csvHeaderRecipientCityPostal": {
+    "message": "Recipient City / Postal",
+    "description": "CSV header for the shipping recipient's city and postal code line"
+  },
+  "csvHeaderRecipientCountry": {
+    "message": "Recipient Country",
+    "description": "CSV header for the shipping recipient's country"
   }
 }

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -226,5 +226,21 @@
   "csvHeaderDetailsUrl": {
     "message": "URL de detalles",
     "description": "CSV header for details URL"
+  },
+  "csvHeaderRecipientName": {
+    "message": "Nombre del destinatario",
+    "description": "CSV header for the shipping recipient's name"
+  },
+  "csvHeaderRecipientStreet": {
+    "message": "Dirección del destinatario",
+    "description": "CSV header for the shipping recipient's street address (may include multiple lines joined by commas)"
+  },
+  "csvHeaderRecipientCityPostal": {
+    "message": "Ciudad / Código postal del destinatario",
+    "description": "CSV header for the shipping recipient's city and postal code line"
+  },
+  "csvHeaderRecipientCountry": {
+    "message": "País del destinatario",
+    "description": "CSV header for the shipping recipient's country"
   }
 }

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -226,5 +226,21 @@
   "csvHeaderDetailsUrl": {
     "message": "URL des détails",
     "description": "CSV header for details URL"
+  },
+  "csvHeaderRecipientName": {
+    "message": "Nom du destinataire",
+    "description": "CSV header for the shipping recipient's name"
+  },
+  "csvHeaderRecipientStreet": {
+    "message": "Adresse du destinataire",
+    "description": "CSV header for the shipping recipient's street address (may include multiple lines joined by commas)"
+  },
+  "csvHeaderRecipientCityPostal": {
+    "message": "Ville / Code postal du destinataire",
+    "description": "CSV header for the shipping recipient's city and postal code line"
+  },
+  "csvHeaderRecipientCountry": {
+    "message": "Pays du destinataire",
+    "description": "CSV header for the shipping recipient's country"
   }
 }

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -545,6 +545,10 @@ import { STORAGE_KEY, STOP_FLAG_KEY } from '../constants';
       detailsUrl: '',
       promotions: [],
       totalSavings: 0,
+      recipientName: '',
+      recipientStreet: '',
+      recipientCityPostal: '',
+      recipientCountry: '',
     };
 
     const orderText = orderEl.textContent || '';
@@ -592,6 +596,13 @@ import { STORAGE_KEY, STOP_FLAG_KEY } from '../constants';
     // Extract Items
     order.items = parseOrderItems(orderEl);
 
+    // Extract Recipient (name + address)
+    const recipient = parseRecipient(orderEl);
+    order.recipientName = recipient.name;
+    order.recipientStreet = recipient.street;
+    order.recipientCityPostal = recipient.cityPostal;
+    order.recipientCountry = recipient.country;
+
     // Filter out advertisement/fake orders
     // These typically have no date, no status, no details URL, and contain ads like "Amazon Visa"
     if (isAdvertisementOrder(order)) {
@@ -600,6 +611,103 @@ import { STORAGE_KEY, STOP_FLAG_KEY } from '../constants';
     }
 
     return order;
+  }
+
+  /**
+   * Parse the recipient (name + shipping address) from an order element.
+   *
+   * Amazon embeds the shipping address inside `.yohtmlc-recipient`:
+   *  - The recipient name is inside `<a class="...insert-encrypted-trigger-text">`
+   *  - The full address is preloaded inside `.a-popover-preload`, as three `.a-row`s:
+   *      1. <h5>Name</h5>
+   *      2. Street lines + city/postal, separated by <br>
+   *      3. Country
+   *
+   * Returns empty strings for any field that cannot be located.
+   */
+  function parseRecipient(orderEl: Element): {
+    name: string;
+    street: string;
+    cityPostal: string;
+    country: string;
+  } {
+    const result = { name: '', street: '', cityPostal: '', country: '' };
+
+    const recipientEl = orderEl.querySelector('.yohtmlc-recipient');
+    if (!recipientEl) return result;
+
+    // Name: the trigger text inside the popover anchor
+    const triggerEl = recipientEl.querySelector(
+      'a.a-popover-trigger, .insert-encrypted-trigger-text'
+    );
+    if (triggerEl) {
+      // textContent includes the trailing icon span; .trim() handles whitespace,
+      // and the icon has no text so it doesn't pollute the result.
+      result.name = (triggerEl.textContent || '').trim();
+    }
+
+    // Full address: from the preloaded popover content
+    const preloadEl = recipientEl.querySelector('.a-popover-preload');
+    if (!preloadEl) return result;
+
+    const rows = preloadEl.querySelectorAll('.a-row');
+    if (rows.length === 0) return result;
+
+    // Fallback for name from the h5 inside the popover
+    if (!result.name) {
+      const h5 = preloadEl.querySelector('h5');
+      if (h5) result.name = (h5.textContent || '').trim();
+    }
+
+    // Walk through rows; skip the name row (the one containing an h5).
+    const addressRows: Element[] = [];
+    rows.forEach((row) => {
+      if (!row.querySelector('h5')) addressRows.push(row);
+    });
+
+    if (addressRows.length === 0) return result;
+
+    // Last address row = country. Everything before = street lines + city/postal.
+    const countryEl = addressRows[addressRows.length - 1];
+    if (countryEl) {
+      result.country = (countryEl.textContent || '').trim();
+    }
+
+    const streetRows = addressRows.slice(0, -1);
+
+    // Each row may contain multiple lines separated by <br>. Replace <br> with \n,
+    // strip remaining HTML, split into lines.
+    const allLines: string[] = [];
+    streetRows.forEach((row) => {
+      const html = row.innerHTML.replace(/<br\s*\/?>/gi, '\n').replace(/<[^>]+>/g, '');
+      const decoded = decodeHtmlEntities(html);
+      decoded
+        .split('\n')
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .forEach((line) => allLines.push(line));
+    });
+
+    if (allLines.length === 0) return result;
+
+    // Heuristic: the last line of the address block is the city + postal code
+    // (e.g. "Châteaumeillant 18370" or "Paris 75009"). Everything above is the
+    // street (possibly multi-line: "27, Rue X" + "Apt B" + ...).
+    result.cityPostal = allLines[allLines.length - 1] ?? '';
+    result.street = allLines.slice(0, -1).join(', ');
+
+    return result;
+  }
+
+  /**
+   * Lightweight HTML entity decoder for the small subset Amazon uses in addresses
+   * (we run inside a content script, so we can also leverage a textarea trick if
+   * needed, but a simple replacement covers the common cases).
+   */
+  function decodeHtmlEntities(text: string): string {
+    const textarea = document.createElement('textarea');
+    textarea.innerHTML = text;
+    return textarea.value;
   }
 
   /**

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -699,15 +699,20 @@ import { STORAGE_KEY, STOP_FLAG_KEY } from '../constants';
     return result;
   }
 
+  // Reused across decodeHtmlEntities calls to avoid allocating a fresh <textarea>
+  // per address row when parsing many orders.
+  let entityDecoderTextarea: HTMLTextAreaElement | null = null;
+
   /**
    * Lightweight HTML entity decoder for the small subset Amazon uses in addresses
-   * (we run inside a content script, so we can also leverage a textarea trick if
-   * needed, but a simple replacement covers the common cases).
+   * (we run inside a content script, so we can leverage the textarea trick).
    */
   function decodeHtmlEntities(text: string): string {
-    const textarea = document.createElement('textarea');
-    textarea.innerHTML = text;
-    return textarea.value;
+    if (!entityDecoderTextarea) {
+      entityDecoderTextarea = document.createElement('textarea');
+    }
+    entityDecoderTextarea.innerHTML = text;
+    return entityDecoderTextarea.value;
   }
 
   /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -21,6 +21,10 @@ export interface Order {
   detailsUrl: string;
   promotions: Promotion[];
   totalSavings: number;
+  recipientName: string;
+  recipientStreet: string;
+  recipientCityPostal: string;
+  recipientCountry: string;
 }
 
 export interface Promotion {

--- a/src/utils/csvUtils.ts
+++ b/src/utils/csvUtils.ts
@@ -50,6 +50,10 @@ export function convertOrdersToCSV(
     getHeader('csvHeaderPromotions'),
     getHeader('csvHeaderItemUrl'),
     getHeader('csvHeaderDetailsUrl'),
+    getHeader('csvHeaderRecipientName'),
+    getHeader('csvHeaderRecipientStreet'),
+    getHeader('csvHeaderRecipientCityPostal'),
+    getHeader('csvHeaderRecipientCountry'),
   ];
 
   const rows: string[] = [headers.join(',')];
@@ -74,6 +78,10 @@ export function convertOrdersToCSV(
           escapeCSVValue(promotionsStr),
           '',
           escapeCSVValue(order.detailsUrl),
+          escapeCSVValue(order.recipientName),
+          escapeCSVValue(order.recipientStreet),
+          escapeCSVValue(order.recipientCityPostal),
+          escapeCSVValue(order.recipientCountry),
         ].join(',')
       );
     } else {
@@ -94,6 +102,10 @@ export function convertOrdersToCSV(
             index === 0 ? escapeCSVValue(promotionsStr) : '',
             escapeCSVValue(item.itemUrl),
             escapeCSVValue(order.detailsUrl),
+            index === 0 ? escapeCSVValue(order.recipientName) : '',
+            index === 0 ? escapeCSVValue(order.recipientStreet) : '',
+            index === 0 ? escapeCSVValue(order.recipientCityPostal) : '',
+            index === 0 ? escapeCSVValue(order.recipientCountry) : '',
           ].join(',')
         );
       });

--- a/tests/csvUtils.test.ts
+++ b/tests/csvUtils.test.ts
@@ -68,6 +68,10 @@ describe('convertOrdersToCSV', () => {
     detailsUrl: 'https://amazon.de/order-details/123',
     promotions: [],
     totalSavings: 0,
+    recipientName: '',
+    recipientStreet: '',
+    recipientCityPostal: '',
+    recipientCountry: '',
     ...overrides,
   });
 
@@ -175,5 +179,67 @@ describe('convertOrdersToCSV', () => {
     ];
     const csv = convertOrdersToCSV(orders);
     expect(csv).toContain('"Product ""with quotes"", and commas"');
+  });
+
+  it('should include recipient fields in headers', () => {
+    const csv = convertOrdersToCSV([]);
+    expect(csv).toContain('csvHeaderRecipientName');
+    expect(csv).toContain('csvHeaderRecipientStreet');
+    expect(csv).toContain('csvHeaderRecipientCityPostal');
+    expect(csv).toContain('csvHeaderRecipientCountry');
+  });
+
+  it('should include recipient values for an order without items', () => {
+    const orders = [
+      createOrder({
+        recipientName: 'Jeremy Ferand',
+        recipientStreet: '2, Lieu-dit La Croix des Marais',
+        recipientCityPostal: 'Châteaumeillant 18370',
+        recipientCountry: 'France',
+      }),
+    ];
+    const csv = convertOrdersToCSV(orders);
+    expect(csv).toContain('Jeremy Ferand');
+    expect(csv).toContain('"2, Lieu-dit La Croix des Marais"');
+    expect(csv).toContain('Châteaumeillant 18370');
+    expect(csv).toContain('France');
+  });
+
+  it('should only include recipient on the first item row of a multi-item order', () => {
+    const orders = [
+      createOrder({
+        recipientName: 'Jeremy Ferand',
+        recipientStreet: '2, Lieu-dit La Croix des Marais',
+        recipientCityPostal: 'Châteaumeillant 18370',
+        recipientCountry: 'France',
+        items: [
+          {
+            title: 'Product 1',
+            asin: 'B000000001',
+            quantity: 1,
+            price: 29.99,
+            discount: 0,
+            itemUrl: 'https://amazon.de/dp/B000000001',
+          },
+          {
+            title: 'Product 2',
+            asin: 'B000000002',
+            quantity: 1,
+            price: 15.0,
+            discount: 0,
+            itemUrl: 'https://amazon.de/dp/B000000002',
+          },
+        ],
+      }),
+    ];
+    const csv = convertOrdersToCSV(orders);
+    const lines = csv.split('\n');
+
+    // First item row should carry the recipient
+    expect(lines[1]).toContain('Jeremy Ferand');
+    // Second item row should not repeat the recipient (last 4 columns must be empty)
+    const secondRowParts = lines[2]!.split(',');
+    const last4 = secondRowParts.slice(-4);
+    expect(last4).toEqual(['', '', '', '']);
   });
 });

--- a/tests/csvUtils.test.ts
+++ b/tests/csvUtils.test.ts
@@ -237,9 +237,10 @@ describe('convertOrdersToCSV', () => {
 
     // First item row should carry the recipient
     expect(lines[1]).toContain('Jeremy Ferand');
-    // Second item row should not repeat the recipient (last 4 columns must be empty)
-    const secondRowParts = lines[2]!.split(',');
-    const last4 = secondRowParts.slice(-4);
-    expect(last4).toEqual(['', '', '', '']);
+    // Second item row should not repeat the recipient: the last 4 columns must
+    // be empty, which serializes as four trailing commas at the end of the row.
+    // Assert this directly instead of splitting on ',', which is not CSV-safe
+    // when earlier columns may contain commas inside quoted fields.
+    expect(lines[2]).toMatch(/,{4}$/);
   });
 });


### PR DESCRIPTION
## Summary

Extracts the shipping recipient (name + full address) from Amazon order history cards and exposes it in the exported JSON and CSV. The information is already rendered in the page, we simply parse it from the `.yohtmlc-recipient` block and its popover preload.


## What changes

- **Types** (`src/types/index.ts`): four new fields on `Order`:
- `recipientName`, `recipientStreet`, `recipientCityPostal`, `recipientCountry`
- **Content script** (`src/content/content.ts`): new `parseRecipient(orderEl)` helper that:
- Reads the name from `a.a-popover-trigger` (or `.insert-encrypted-trigger-text` as a fallback)
- Reads the address from `.a-popover-preload > .a-row`s, decoding `<br>`-separated lines
- Splits street lines vs. city/postal using the last-line-is-city heuristic
- Returns empty strings when any field is missing — never throws
- **CSV** (`src/utils/csvUtils.ts`): four new columns appended after `Details URL`. For multi-item orders, the recipient is emitted only on the first item row, mirroring how `totalSavings` and `promotions` are handled today.
- **i18n** (`src/_locales/{en,fr,de,es}/messages.json`): four new header keys, translated per locale.
- **Tests** (`tests/csvUtils.test.ts`): default fixture updated; new tests cover the presence of the four headers, the value passthrough for orderless-items rows, and the first-item-row constraint for multi-item orders.
- **README**: JSON schema and CSV column table updated to reflect the new fields.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run test` (143/143 including 3 new)
- [x] `npm run build` (Firefox MV2 + Chrome MV3)
- [x] Loaded the Chrome build locally, exported orders from `amazon.com/your-orders/orders`, verified the four new columns render correct values on a real order (name + street + city/postal + country all extracted).