### PR TITLE
feat: transaction dates & amounts (rebased & review-fixed #23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Browser extension for exporting your Amazon order history to JSON or CSV format.
 - **Date Range Filtering** — Export orders within a specific date range
 - **Multiple Formats** — Export as JSON or CSV
 - **Cancellable Exports** — Stop an export while it is in progress
+- **Transaction Details** — Optionally include the actual charged amount and transaction date per order, sourced from Amazon's payments page (not the pre-tax subtotal)
 - **Privacy Focused** — No tracking or data collection; all processing happens locally
 - **Open Source** — Free to use and modify
 
@@ -121,8 +122,9 @@ The built extensions will be in browser-specific directories:
 2. Navigate to Amazon and log in to your account
 3. Click the extension icon in the toolbar
 4. Select your export options (date range, format)
-5. Click "Export" to download your order history
-6. To cancel an export in progress, reopen the popup and click "Stop Export"
+5. Optionally check **Include transaction details** to add the actual charged amount and transaction date to each order — this fetches one extra page per order so exports will take longer
+6. Click "Export" to download your order history
+7. To cancel an export in progress, reopen the popup and click "Stop Export"
 
 ---
 
@@ -130,7 +132,7 @@ The built extensions will be in browser-specific directories:
 
 ### JSON Format
 
-The data model for each order includes the following fields:
+The data model for each order includes the following fields. The `transactions` field is only present when "Include transaction details" is enabled.
 
 ```json
 {
@@ -160,7 +162,14 @@ The data model for each order includes the following fields:
     "recipientName": "string (shipping recipient's name)",
     "recipientStreet": "string (street lines joined by commas; may be empty)",
     "recipientCityPostal": "string (city and postal code line; may be empty)",
-    "recipientCountry": "string (may be empty)"
+    "recipientCountry": "string (may be empty)",
+    "transactions": [
+        {
+            "date": "string (ISO 8601 date)",
+            "amount": "number (positive = charge, negative = refund)",
+            "currency": "string"
+        }
+    ]
 }
 ```
 
@@ -188,6 +197,8 @@ The CSV export creates multiple rows for orders with multiple items. Columns:
 | Recipient Street | Shipping street address, multi-line joined by commas (on the first item row only) |
 | Recipient City / Postal | Shipping city and postal code line (on the first item row only) |
 | Recipient Country | Shipping country (on the first item row only) |
+| Transaction Dates | Date(s) Amazon charged your payment method (pipe-separated if multiple); only present when "Include transaction details" is enabled |
+| Transaction Amounts | Charged amount(s) — positive for charges, negative for refunds (pipe-separated if multiple); only present when "Include transaction details" is enabled |
 
 ---
 

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -117,6 +117,24 @@
       }
     }
   },
+  "includeTransactions": {
+    "message": "Transaktionsdetails einschließen",
+    "description": "Checkbox label to include per-order transaction data"
+  },
+  "includeTransactionsHint": {
+    "message": "Lädt eine zusätzliche Seite pro Bestellung – langsamer",
+    "description": "Hint text below the include transactions checkbox"
+  },
+  "fetchingPricesAndTransactions": {
+    "message": "Lade Preise und Transaktionen für $COUNT$ Bestellungen...",
+    "description": "Progress message when fetching both prices and transactions",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "25"
+      }
+    }
+  },
   "fetchingPrices": {
     "message": "Lade Preise für $COUNT$ Bestellungen...",
     "description": "Progress message while fetching prices",
@@ -242,5 +260,13 @@
   "csvHeaderRecipientCountry": {
     "message": "Empfängerland",
     "description": "CSV header for the shipping recipient's country"
+  },
+  "csvHeaderTransactionDates": {
+    "message": "Transaktionsdaten",
+    "description": "CSV header for transaction dates"
+  },
+  "csvHeaderTransactionAmounts": {
+    "message": "Transaktionsbeträge",
+    "description": "CSV header for transaction amounts"
   }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -117,6 +117,24 @@
       }
     }
   },
+  "includeTransactions": {
+    "message": "Include transaction details",
+    "description": "Checkbox label to include per-order transaction data"
+  },
+  "includeTransactionsHint": {
+    "message": "Fetches an extra page per order — slower",
+    "description": "Hint text below the include transactions checkbox"
+  },
+  "fetchingPricesAndTransactions": {
+    "message": "Fetching prices and transactions for $COUNT$ orders...",
+    "description": "Progress message when fetching both prices and transactions",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "25"
+      }
+    }
+  },
   "fetchingPrices": {
     "message": "Fetching item prices for $COUNT$ orders...",
     "description": "Progress message while fetching prices",
@@ -242,5 +260,13 @@
   "csvHeaderRecipientCountry": {
     "message": "Recipient Country",
     "description": "CSV header for the shipping recipient's country"
+  },
+  "csvHeaderTransactionDates": {
+    "message": "Transaction Dates",
+    "description": "CSV header for transaction dates"
+  },
+  "csvHeaderTransactionAmounts": {
+    "message": "Transaction Amounts",
+    "description": "CSV header for transaction amounts"
   }
 }

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -117,6 +117,24 @@
       }
     }
   },
+  "includeTransactions": {
+    "message": "Incluir detalles de transacción",
+    "description": "Checkbox label to include per-order transaction data"
+  },
+  "includeTransactionsHint": {
+    "message": "Obtiene una página extra por pedido — más lento",
+    "description": "Hint text below the include transactions checkbox"
+  },
+  "fetchingPricesAndTransactions": {
+    "message": "Obteniendo precios y transacciones para $COUNT$ pedidos...",
+    "description": "Progress message when fetching both prices and transactions",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "25"
+      }
+    }
+  },
   "fetchingPrices": {
     "message": "Obteniendo precios de artículos para $COUNT$ pedidos...",
     "description": "Progress message while fetching prices",
@@ -242,5 +260,13 @@
   "csvHeaderRecipientCountry": {
     "message": "País del destinatario",
     "description": "CSV header for the shipping recipient's country"
+  },
+  "csvHeaderTransactionDates": {
+    "message": "Fechas de transacción",
+    "description": "CSV header for transaction dates"
+  },
+  "csvHeaderTransactionAmounts": {
+    "message": "Importes de transacción",
+    "description": "CSV header for transaction amounts"
   }
 }

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -117,6 +117,24 @@
       }
     }
   },
+  "includeTransactions": {
+    "message": "Inclure les détails de transaction",
+    "description": "Checkbox label to include per-order transaction data"
+  },
+  "includeTransactionsHint": {
+    "message": "Récupère une page supplémentaire par commande — plus lent",
+    "description": "Hint text below the include transactions checkbox"
+  },
+  "fetchingPricesAndTransactions": {
+    "message": "Récupération des prix et transactions pour $COUNT$ commandes...",
+    "description": "Progress message when fetching both prices and transactions",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "25"
+      }
+    }
+  },
   "fetchingPrices": {
     "message": "Récupération des prix pour $COUNT$ commandes...",
     "description": "Progress message while fetching prices",
@@ -242,5 +260,13 @@
   "csvHeaderRecipientCountry": {
     "message": "Pays du destinataire",
     "description": "CSV header for the shipping recipient's country"
+  },
+  "csvHeaderTransactionDates": {
+    "message": "Dates de transaction",
+    "description": "CSV header for transaction dates"
+  },
+  "csvHeaderTransactionAmounts": {
+    "message": "Montants des transactions",
+    "description": "CSV header for transaction amounts"
   }
 }

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -4,7 +4,14 @@
  */
 
 import browser from 'webextension-polyfill';
-import type { ExportOptions, ExportState, Order, OrderItem, Promotion } from '../types';
+import type {
+  ExportOptions,
+  ExportState,
+  Order,
+  OrderItem,
+  Promotion,
+  Transaction,
+} from '../types';
 import {
   parseOrderDate,
   extractOrderYear,
@@ -20,6 +27,8 @@ import {
   parsePrice,
   CURRENCY_TOKEN,
   parseOrderStatus,
+  buildTransactionUrl,
+  parseCPETransactionAmount,
 } from '../utils';
 import { STORAGE_KEY, STOP_FLAG_KEY } from '../constants';
 
@@ -81,7 +90,13 @@ import { STORAGE_KEY, STOP_FLAG_KEY } from '../constants';
   function getExportState(): ExportState | null {
     try {
       const data = sessionStorage.getItem(STORAGE_KEY);
-      return data ? (JSON.parse(data) as ExportState) : null;
+      if (!data) return null;
+      const state = JSON.parse(data) as ExportState;
+      // Default field added in a later version — ensure backward compatibility
+      if (typeof state.includeTransactions !== 'boolean') {
+        state.includeTransactions = false;
+      }
+      return state;
     } catch {
       return null;
     }
@@ -145,7 +160,7 @@ import { STORAGE_KEY, STOP_FLAG_KEY } from '../constants';
     // Reset stop flag for fresh export
     stopRequested = false;
 
-    const { format, startDate, endDate, exportAll } = options;
+    const { format, startDate, endDate, exportAll, includeTransactions } = options;
 
     // Get available years
     const years = getAvailableYears();
@@ -170,6 +185,7 @@ import { STORAGE_KEY, STOP_FLAG_KEY } from '../constants';
       startDate: startDate,
       endDate: endDate,
       exportAll: exportAll,
+      includeTransactions,
       yearsToProcess: yearsToProcess,
       currentYearIndex: 0,
       currentStartIndex: 0,
@@ -230,7 +246,7 @@ import { STORAGE_KEY, STOP_FLAG_KEY } from '../constants';
     const endDateObj = state.endDate ? new Date(state.endDate) : null;
 
     // Scrape orders from current page
-    const pageOrders = scrapeVisibleOrders(
+    const { orders: pageOrders, passedStartDate } = scrapeVisibleOrders(
       startDateObj,
       endDateObj,
       state.exportAll,
@@ -250,7 +266,11 @@ import { STORAGE_KEY, STOP_FLAG_KEY } from '../constants';
     // Check if there are more pages for current year
     const hasNextPage = checkForNextPage();
 
-    if (hasNextPage && pageOrders.length > 0) {
+    // Continue to the next page if Amazon shows one AND we haven't gone past the
+    // start date yet. In date-range mode, Amazon lists orders newest-first, so
+    // early pages may have zero matches (all too new) — we must keep paginating
+    // until we either find matches or encounter orders older than startDate.
+    if (hasNextPage && !passedStartDate) {
       // Navigate to next page of current year
       state.currentStartIndex += 10;
       saveExportState(state);
@@ -291,10 +311,19 @@ import { STORAGE_KEY, STOP_FLAG_KEY } from '../constants';
   async function finishExport(state: ExportState): Promise<void> {
     console.log('[Amazon Exporter] Export complete. Total orders:', state.collectedOrders.length);
 
-    updateProgress(80, getMessage('fetchingPrices', [String(state.collectedOrders.length)]));
+    updateProgress(
+      80,
+      state.includeTransactions
+        ? getMessage('fetchingPricesAndTransactions', [String(state.collectedOrders.length)])
+        : getMessage('fetchingPrices', [String(state.collectedOrders.length)])
+    );
 
-    // Fetch item prices for multi-item orders
-    await fetchOrderDetailsForPrices(state.collectedOrders);
+    // Fetch item prices (and optionally transaction details) for all orders
+    await fetchOrderDetailsForPrices(
+      state.collectedOrders,
+      state.includeTransactions,
+      state.baseUrl
+    );
 
     // Check if stop was requested during price fetching (state already cleared by handler)
     if (stopRequested || !getExportState()) {
@@ -310,11 +339,14 @@ import { STORAGE_KEY, STOP_FLAG_KEY } from '../constants';
     const timestamp = new Date().toISOString().split('T')[0];
 
     if (state.format === 'json') {
-      fileContent = JSON.stringify(state.collectedOrders, null, 2);
+      const jsonOrders = state.includeTransactions
+        ? state.collectedOrders
+        : state.collectedOrders.map(({ transactions: _tx, ...rest }) => rest);
+      fileContent = JSON.stringify(jsonOrders, null, 2);
       fileName = `amazon-orders-${timestamp}.json`;
       mimeType = 'application/json';
     } else {
-      fileContent = convertToCSV(state.collectedOrders);
+      fileContent = convertToCSV(state.collectedOrders, state.includeTransactions);
       fileName = `amazon-orders-${timestamp}.csv`;
       mimeType = 'text/csv';
     }
@@ -448,8 +480,9 @@ import { STORAGE_KEY, STOP_FLAG_KEY } from '../constants';
     endDateObj: Date | null,
     exportAll: boolean,
     seenOrderIds: Set<string>
-  ): Order[] {
+  ): { orders: Order[]; passedStartDate: boolean } {
     const orders: Order[] = [];
+    let passedStartDate = false;
 
     console.log('[Amazon Exporter] Scraping visible page...');
     console.log('[Amazon Exporter] URL:', window.location.href);
@@ -516,7 +549,19 @@ import { STORAGE_KEY, STOP_FLAG_KEY } from '../constants';
           // Filter by date if specified
           if (!exportAll && startDateObj && endDateObj && order.orderDate) {
             const orderDateObj = new Date(order.orderDate);
-            if (orderDateObj < startDateObj || orderDateObj > endDateObj) {
+            if (orderDateObj < startDateObj) {
+              // This order is older than our start date. Since Amazon lists orders
+              // newest-first, all subsequent pages will also be out-of-range.
+              passedStartDate = true;
+              console.log(
+                `[Amazon Exporter] Skipping order ${order.orderId}: date ${order.orderDate} before range start ${startDateObj.toISOString().split('T')[0]}`
+              );
+              return;
+            }
+            if (orderDateObj > endDateObj) {
+              console.log(
+                `[Amazon Exporter] Skipping order ${order.orderId}: date ${order.orderDate} after range end ${endDateObj.toISOString().split('T')[0]}`
+              );
               return;
             }
           }
@@ -531,7 +576,7 @@ import { STORAGE_KEY, STOP_FLAG_KEY } from '../constants';
       }
     });
 
-    return orders;
+    return { orders, passedStartDate };
   }
 
   /**
@@ -568,7 +613,7 @@ import { STORAGE_KEY, STOP_FLAG_KEY } from '../constants';
     // Extract Order ID
     order.orderId = extractOrderId(orderText) || '';
 
-    // Try links for order ID
+    // Try links for order ID via orderID=/orderId= query param
     if (!order.orderId) {
       const links = orderEl.querySelectorAll('a[href]');
       for (const link of links) {
@@ -579,6 +624,46 @@ import { STORAGE_KEY, STOP_FLAG_KEY } from '../constants';
           break;
         }
       }
+    }
+
+    // Try data attributes on the order element and its children
+    if (!order.orderId) {
+      const attrTargets: (Element | null)[] = [
+        orderEl,
+        ...Array.from(orderEl.querySelectorAll('[data-order-id], [data-orderid], [data-order]')),
+      ];
+      for (const el of attrTargets) {
+        if (!el) continue;
+        const raw =
+          el.getAttribute('data-order-id') ||
+          el.getAttribute('data-orderid') ||
+          el.getAttribute('data-order') ||
+          el.id ||
+          '';
+        const match = raw.match(/\d{3}-\d{7}-\d{7}/);
+        if (match?.[0]) {
+          order.orderId = match[0];
+          break;
+        }
+      }
+    }
+
+    // Last resort: scan every link href for the order ID pattern directly
+    if (!order.orderId) {
+      const allLinks = orderEl.querySelectorAll('a[href]');
+      for (const link of allLinks) {
+        const href = (link as HTMLAnchorElement).href || link.getAttribute('href') || '';
+        const match = href.match(/\d{3}-\d{7}-\d{7}/);
+        if (match?.[0]) {
+          order.orderId = match[0];
+          break;
+        }
+      }
+    }
+
+    if (!order.orderId) {
+      const snippet = orderText.replace(/\s+/g, ' ').trim().substring(0, 150);
+      console.warn(`[Amazon Exporter] Could not extract order ID. Card text: "${snippet}"`);
     }
 
     // Extract order details URL
@@ -835,11 +920,13 @@ import { STORAGE_KEY, STOP_FLAG_KEY } from '../constants';
   }
 
   /**
-   * Fetch order details for item prices and discounts
+   * Fetch order details for item prices, discounts, and (optionally) transactions
    */
-  async function fetchOrderDetailsForPrices(orders: Order[]): Promise<void> {
-    // We need to fetch details for all orders to get accurate pricing and discounts
-    // Even single-item orders can have discounts
+  async function fetchOrderDetailsForPrices(
+    orders: Order[],
+    includeTransactions: boolean,
+    _baseUrl: string
+  ): Promise<void> {
     const ordersNeedingDetails = orders.filter((order) => order.detailsUrl);
 
     console.log('[Amazon Exporter] Fetching details for', ordersNeedingDetails.length, 'orders');
@@ -863,20 +950,109 @@ import { STORAGE_KEY, STOP_FLAG_KEY } from '../constants';
           credentials: 'include',
         });
 
-        if (!response.ok) continue;
+        if (response.ok) {
+          const html = await response.text();
+          const parser = new DOMParser();
+          const doc = parser.parseFromString(html, 'text/html');
+          parseItemPricesFromDetails(order, doc);
+          parsePromotionsFromDetails(order, doc);
+        }
 
-        const html = await response.text();
-        const parser = new DOMParser();
-        const doc = parser.parseFromString(html, 'text/html');
+        // Fetch the CPE transaction page for actual charged amounts.
+        // Derive the origin per-order from its detailsUrl: users can have
+        // orders across multiple locales (amazon.com + amazon.de) in the same
+        // export, so a single global origin would be wrong. If detailsUrl
+        // isn't a valid URL, skip transactions for this order.
+        if (includeTransactions && order.orderId) {
+          let transactionOrigin = '';
+          try {
+            transactionOrigin = new URL(order.detailsUrl).origin;
+          } catch {
+            console.warn(
+              '[Amazon Exporter] Could not derive origin from detailsUrl for order:',
+              order.orderId
+            );
+          }
 
-        parseItemPricesFromDetails(order, doc);
-        parsePromotionsFromDetails(order, doc);
+          if (transactionOrigin) {
+            await new Promise((resolve) => setTimeout(resolve, 200));
+
+            const txUrl = buildTransactionUrl(transactionOrigin, order.orderId);
+            try {
+              const txResponse = await fetch(txUrl, { credentials: 'include' });
+              if (txResponse.ok) {
+                const txHtml = await txResponse.text();
+                const txParser = new DOMParser();
+                const txDoc = txParser.parseFromString(txHtml, 'text/html');
+                order.transactions = parseTransactionsFromCPEDoc(txDoc);
+                if (order.transactions.length > 0) {
+                  console.log(
+                    `[Amazon Exporter] ${order.transactions.length} transaction(s) from CPE page for order ${order.orderId}`
+                  );
+                } else {
+                  console.warn(
+                    `[Amazon Exporter] No transactions found in CPE page for ${order.orderId}`
+                  );
+                }
+              }
+            } catch (txError) {
+              console.warn(
+                '[Amazon Exporter] Error fetching transactions for order:',
+                order.orderId,
+                txError
+              );
+              order.transactions = [];
+            }
+          }
+        }
 
         await new Promise((resolve) => setTimeout(resolve, 200));
       } catch (error) {
         console.warn('[Amazon Exporter] Error fetching details:', error);
       }
     }
+  }
+
+  /**
+   * Walk the CPE (`/cpe/yourpayments/transactions`) DOM and extract per-order
+   * transactions. DOM traversal lives here in the content script; sign/amount
+   * parsing is delegated to the pure `parseCPETransactionAmount` utility so it
+   * can be unit-tested without jsdom.
+   */
+  function parseTransactionsFromCPEDoc(doc: Document): Transaction[] {
+    const transactions: Transaction[] = [];
+    const seen = new Set<string>();
+
+    const groups = doc.querySelectorAll('.a-box-group');
+    for (const group of groups) {
+      const dateEl = group.querySelector('.apx-transaction-date-container span');
+      if (!dateEl) continue;
+
+      const dateText = dateEl.textContent?.trim() ?? '';
+      const date = parseOrderDate(dateText);
+      if (!date) continue;
+
+      const amountEls = group.querySelectorAll(
+        '.a-column.a-span3.a-text-right.a-span-last .a-size-base-plus.a-text-bold,' +
+          '.apx-transactions-line-item-component-container .a-size-base-plus.a-text-bold'
+      );
+
+      for (const amountEl of amountEls) {
+        const amountText = amountEl.textContent?.trim() ?? '';
+        if (!amountText) continue;
+
+        const parsed = parseCPETransactionAmount(amountText);
+        if (!parsed) continue;
+
+        const key = `${date}:${parsed.amount}`;
+        if (!seen.has(key)) {
+          seen.add(key);
+          transactions.push({ date, amount: parsed.amount, currency: parsed.currency });
+        }
+      }
+    }
+
+    return transactions;
   }
 
   /**
@@ -1104,8 +1280,8 @@ import { STORAGE_KEY, STOP_FLAG_KEY } from '../constants';
   /**
    * Convert orders to CSV format (wrapper using utility function)
    */
-  function convertToCSV(orders: Order[]): string {
-    return convertOrdersToCSV(orders, getMessage);
+  function convertToCSV(orders: Order[], includeTransactions: boolean): string {
+    return convertOrdersToCSV(orders, getMessage, includeTransactions);
   }
 
   /**

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -319,11 +319,7 @@ import { STORAGE_KEY, STOP_FLAG_KEY } from '../constants';
     );
 
     // Fetch item prices (and optionally transaction details) for all orders
-    await fetchOrderDetailsForPrices(
-      state.collectedOrders,
-      state.includeTransactions,
-      state.baseUrl
-    );
+    await fetchOrderDetailsForPrices(state.collectedOrders, state.includeTransactions);
 
     // Check if stop was requested during price fetching (state already cleared by handler)
     if (stopRequested || !getExportState()) {
@@ -924,8 +920,7 @@ import { STORAGE_KEY, STOP_FLAG_KEY } from '../constants';
    */
   async function fetchOrderDetailsForPrices(
     orders: Order[],
-    includeTransactions: boolean,
-    _baseUrl: string
+    includeTransactions: boolean
   ): Promise<void> {
     const ordersNeedingDetails = orders.filter((order) => order.detailsUrl);
 

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -241,6 +241,40 @@ footer a:hover {
   display: none !important;
 }
 
+.checkbox-label {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  cursor: pointer;
+  padding: 10px 12px;
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  transition: all 0.2s ease;
+}
+
+.checkbox-label:hover {
+  border-color: #ff9900;
+  background: #fff8e5;
+}
+
+.checkbox-label input[type='checkbox'] {
+  margin-top: 2px;
+  accent-color: #ff9900;
+  flex-shrink: 0;
+}
+
+.checkbox-content {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.hint {
+  font-size: 11px;
+  color: #888;
+}
+
 /* Smooth transition for settings visibility */
 #settings-section {
   transition: opacity 0.2s ease;

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -66,6 +66,18 @@
               </label>
             </div>
           </section>
+
+          <section class="section">
+            <label class="checkbox-label">
+              <input type="checkbox" id="includeTransactions" />
+              <div class="checkbox-content">
+                <span data-i18n="includeTransactions">Include transaction details</span>
+                <span class="hint" data-i18n="includeTransactionsHint"
+                  >Fetches an extra page per order — slower</span
+                >
+              </div>
+            </label>
+          </section>
         </div>
 
         <section class="section">

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -45,6 +45,17 @@ document.addEventListener('DOMContentLoaded', async () => {
   const startDateInput = document.getElementById('startDate') as HTMLInputElement;
   const endDateInput = document.getElementById('endDate') as HTMLInputElement;
   const settingsSection = document.getElementById('settings-section') as HTMLElement;
+  const includeTransactionsCheckbox = document.getElementById(
+    'includeTransactions'
+  ) as HTMLInputElement;
+
+  // Restore persisted checkbox state
+  const stored = await browser.storage.local.get('includeTransactions');
+  includeTransactionsCheckbox.checked = stored['includeTransactions'] === true;
+
+  includeTransactionsCheckbox.addEventListener('change', () => {
+    void browser.storage.local.set({ includeTransactions: includeTransactionsCheckbox.checked });
+  });
 
   // Set default date values
   const today = new Date();
@@ -124,6 +135,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         startDate: startDate,
         endDate: endDate,
         exportAll: exportRange === 'all',
+        includeTransactions: includeTransactionsCheckbox.checked,
       };
 
       // Send message to content script

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,6 +11,12 @@ export interface OrderItem {
   itemUrl: string;
 }
 
+export interface Transaction {
+  date: string;
+  amount: number;
+  currency: string;
+}
+
 export interface Order {
   orderId: string;
   orderDate: string;
@@ -25,6 +31,7 @@ export interface Order {
   recipientStreet: string;
   recipientCityPostal: string;
   recipientCountry: string;
+  transactions?: Transaction[];
 }
 
 export interface Promotion {
@@ -37,6 +44,7 @@ export interface ExportOptions {
   startDate: string | null;
   endDate: string | null;
   exportAll: boolean;
+  includeTransactions: boolean;
 }
 
 export interface ExportState {
@@ -45,6 +53,7 @@ export interface ExportState {
   startDate: string | null;
   endDate: string | null;
   exportAll: boolean;
+  includeTransactions: boolean;
   yearsToProcess: string[];
   currentYearIndex: number;
   currentStartIndex: number;

--- a/src/utils/csvUtils.ts
+++ b/src/utils/csvUtils.ts
@@ -3,6 +3,7 @@
  */
 
 import type { Order } from '../types';
+import { formatTransactionDatesForCSV, formatTransactionAmountsForCSV } from './transactionUtils';
 
 /**
  * Escape a value for CSV format
@@ -30,10 +31,12 @@ export function formatPromotionsForCSV(
  * Convert orders to CSV format
  * @param orders - Array of orders to convert
  * @param getHeader - Function to get localized header name
+ * @param includeTransactions - Whether to add Transaction Dates and Transaction Amounts columns
  */
 export function convertOrdersToCSV(
   orders: Order[],
-  getHeader: (key: string) => string = (key) => key
+  getHeader: (key: string) => string = (key) => key,
+  includeTransactions: boolean = false
 ): string {
   const headers = [
     getHeader('csvHeaderOrderId'),
@@ -56,10 +59,27 @@ export function convertOrdersToCSV(
     getHeader('csvHeaderRecipientCountry'),
   ];
 
+  if (includeTransactions) {
+    headers.push(getHeader('csvHeaderTransactionDates'));
+    headers.push(getHeader('csvHeaderTransactionAmounts'));
+  }
+
   const rows: string[] = [headers.join(',')];
 
   orders.forEach((order) => {
     const promotionsStr = formatPromotionsForCSV(order.promotions);
+    const transactions = order.transactions ?? [];
+    const txDates = includeTransactions
+      ? escapeCSVValue(formatTransactionDatesForCSV(transactions))
+      : null;
+    const txAmounts = includeTransactions
+      ? escapeCSVValue(formatTransactionAmountsForCSV(transactions))
+      : null;
+
+    const txColumns = (firstRow: boolean): (string | number)[] => {
+      if (!includeTransactions) return [];
+      return firstRow ? [txDates ?? '', txAmounts ?? ''] : ['', ''];
+    };
 
     if (order.items.length === 0) {
       rows.push(
@@ -82,6 +102,7 @@ export function convertOrdersToCSV(
           escapeCSVValue(order.recipientStreet),
           escapeCSVValue(order.recipientCityPostal),
           escapeCSVValue(order.recipientCountry),
+          ...txColumns(true),
         ].join(',')
       );
     } else {
@@ -106,6 +127,7 @@ export function convertOrdersToCSV(
             index === 0 ? escapeCSVValue(order.recipientStreet) : '',
             index === 0 ? escapeCSVValue(order.recipientCityPostal) : '',
             index === 0 ? escapeCSVValue(order.recipientCountry) : '',
+            ...txColumns(index === 0),
           ].join(',')
         );
       });

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -8,3 +8,4 @@ export * from './orderUtils';
 export * from './statusUtils';
 export * from './csvUtils';
 export * from './urlUtils';
+export * from './transactionUtils';

--- a/src/utils/transactionUtils.ts
+++ b/src/utils/transactionUtils.ts
@@ -1,0 +1,44 @@
+/**
+ * Transaction URL building, CSV formatting, and pure text parsing utilities.
+ *
+ * DOM traversal for CPE pages lives in the content script (see
+ * `parseTransactionsFromCPEDoc` in content.ts). Utilities here are pure data
+ * transforms so they can be unit-tested without a DOM implementation.
+ */
+
+import type { Transaction } from '../types';
+import { extractPriceFromText } from './priceUtils';
+
+export function buildTransactionUrl(origin: string, orderId: string): string {
+  return `${origin}/cpe/yourpayments/transactions?transactionTag=${encodeURIComponent(orderId)}`;
+}
+
+export function formatTransactionDatesForCSV(transactions: Transaction[]): string {
+  if (transactions.length === 0) return '';
+  return transactions.map((t) => t.date).join(' | ');
+}
+
+export function formatTransactionAmountsForCSV(transactions: Transaction[]): string {
+  if (transactions.length === 0) return '';
+  return transactions.map((t) => String(t.amount)).join(' | ');
+}
+
+/**
+ * Convert a raw amount string from Amazon's CPE page into a signed transaction
+ * amount. Amazon shows charges as "-$X.XX" (debit) and refunds as "$X.XX"
+ * (credit). We normalize so the export reflects the user's perspective —
+ * positive means paid, negative means refunded.
+ *
+ * Returns null when no numeric amount could be parsed.
+ */
+export function parseCPETransactionAmount(
+  amountText: string
+): { amount: number; currency: string } | null {
+  const isDebit = /^[-−]/.test(amountText.trim());
+  const price = extractPriceFromText(amountText);
+  if (!price || price.amount === 0) return null;
+  return {
+    amount: isDebit ? price.amount : -price.amount,
+    currency: price.currency,
+  };
+}

--- a/tests/csvUtils.test.ts
+++ b/tests/csvUtils.test.ts
@@ -243,4 +243,95 @@ describe('convertOrdersToCSV', () => {
     // when earlier columns may contain commas inside quoted fields.
     expect(lines[2]).toMatch(/,{4}$/);
   });
+
+  describe('transaction columns', () => {
+    it('should not include transaction columns when includeTransactions is false', () => {
+      const orders = [createOrder()];
+      const csv = convertOrdersToCSV(orders, undefined, false);
+      expect(csv).not.toContain('csvHeaderTransactionDates');
+      expect(csv).not.toContain('csvHeaderTransactionAmounts');
+      const headerCols = csv.split('\n')[0]!.split(',');
+      expect(headerCols.length).toBe(18);
+    });
+
+    it('should include transaction columns when includeTransactions is true', () => {
+      const orders = [createOrder()];
+      const csv = convertOrdersToCSV(orders, undefined, true);
+      expect(csv).toContain('csvHeaderTransactionDates');
+      expect(csv).toContain('csvHeaderTransactionAmounts');
+      const headerCols = csv.split('\n')[0]!.split(',');
+      expect(headerCols.length).toBe(20);
+    });
+
+    it('should populate transaction columns from order.transactions on first item row', () => {
+      const orders = [
+        createOrder({
+          transactions: [
+            { date: '2026-04-17', amount: 14.93, currency: 'USD' },
+            { date: '2026-04-20', amount: 61.01, currency: 'USD' },
+          ],
+          items: [
+            {
+              title: 'Product 1',
+              asin: 'B000000001',
+              quantity: 1,
+              price: 14.93,
+              discount: 0,
+              itemUrl: 'https://amazon.de/dp/B000000001',
+            },
+            {
+              title: 'Product 2',
+              asin: 'B000000002',
+              quantity: 1,
+              price: 61.01,
+              discount: 0,
+              itemUrl: 'https://amazon.de/dp/B000000002',
+            },
+          ],
+        }),
+      ];
+      const csv = convertOrdersToCSV(orders, undefined, true);
+      const lines = csv.split('\n');
+
+      // First item row should have transaction data
+      expect(lines[1]).toContain('2026-04-17 | 2026-04-20');
+      expect(lines[1]).toContain('14.93 | 61.01');
+
+      // Second item row should have empty transaction columns
+      const secondRowCols = lines[2]!.split(',');
+      expect(secondRowCols[18]).toBe('');
+      expect(secondRowCols[19]).toBe('');
+    });
+
+    it('should leave transaction columns empty when order has no transactions', () => {
+      const orders = [createOrder({ transactions: [] })];
+      const csv = convertOrdersToCSV(orders, undefined, true);
+      const lines = csv.split('\n');
+      const dataCols = lines[1]!.split(',');
+      expect(dataCols[18]).toBe('');
+      expect(dataCols[19]).toBe('');
+    });
+
+    it('should leave transaction columns empty when order.transactions is undefined', () => {
+      const orders = [createOrder()]; // no transactions field
+      const csv = convertOrdersToCSV(orders, undefined, true);
+      const lines = csv.split('\n');
+      const dataCols = lines[1]!.split(',');
+      expect(dataCols[18]).toBe('');
+      expect(dataCols[19]).toBe('');
+    });
+
+    it('should populate transaction columns for order with no items', () => {
+      const orders = [
+        createOrder({
+          items: [],
+          transactions: [{ date: '2026-04-17', amount: 75.94, currency: 'USD' }],
+        }),
+      ];
+      const csv = convertOrdersToCSV(orders, undefined, true);
+      const lines = csv.split('\n');
+      expect(lines[1]).toContain('2026-04-17');
+      expect(lines[1]).toContain('75.94');
+    });
+  });
 });

--- a/tests/transactionUtils.test.ts
+++ b/tests/transactionUtils.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildTransactionUrl,
+  formatTransactionDatesForCSV,
+  formatTransactionAmountsForCSV,
+  parseCPETransactionAmount,
+} from '../src/utils/transactionUtils';
+import type { Transaction } from '../src/types';
+
+describe('buildTransactionUrl', () => {
+  it('should build the correct URL for amazon.com', () => {
+    const url = buildTransactionUrl('https://www.amazon.com', '112-1234567-1234567');
+    expect(url).toBe(
+      'https://www.amazon.com/cpe/yourpayments/transactions?transactionTag=112-1234567-1234567'
+    );
+  });
+
+  it('should build the correct URL for amazon.de', () => {
+    const url = buildTransactionUrl('https://www.amazon.de', '123-4567890-1234567');
+    expect(url).toBe(
+      'https://www.amazon.de/cpe/yourpayments/transactions?transactionTag=123-4567890-1234567'
+    );
+  });
+
+  it('should build the correct URL for amazon.co.uk', () => {
+    const url = buildTransactionUrl('https://www.amazon.co.uk', '026-9876543-2109876');
+    expect(url).toBe(
+      'https://www.amazon.co.uk/cpe/yourpayments/transactions?transactionTag=026-9876543-2109876'
+    );
+  });
+
+  it('should URL-encode the order ID', () => {
+    const url = buildTransactionUrl('https://www.amazon.com', '112-1234567-1234567');
+    expect(url).toContain('transactionTag=112-1234567-1234567');
+  });
+
+  it('should use the provided origin verbatim', () => {
+    const url = buildTransactionUrl('https://www.amazon.fr', '111-2222222-3333333');
+    expect(url.startsWith('https://www.amazon.fr')).toBe(true);
+  });
+});
+
+describe('formatTransactionDatesForCSV', () => {
+  it('should return empty string for no transactions', () => {
+    expect(formatTransactionDatesForCSV([])).toBe('');
+  });
+
+  it('should return the date for a single transaction', () => {
+    const transactions: Transaction[] = [{ date: '2026-04-17', amount: 14.93, currency: 'USD' }];
+    expect(formatTransactionDatesForCSV(transactions)).toBe('2026-04-17');
+  });
+
+  it('should join multiple dates with " | "', () => {
+    const transactions: Transaction[] = [
+      { date: '2026-04-17', amount: 14.93, currency: 'USD' },
+      { date: '2026-04-20', amount: 61.01, currency: 'USD' },
+    ];
+    expect(formatTransactionDatesForCSV(transactions)).toBe('2026-04-17 | 2026-04-20');
+  });
+
+  it('should handle three transactions', () => {
+    const transactions: Transaction[] = [
+      { date: '2026-01-01', amount: 10.0, currency: 'EUR' },
+      { date: '2026-01-05', amount: 20.0, currency: 'EUR' },
+      { date: '2026-01-10', amount: 5.5, currency: 'EUR' },
+    ];
+    expect(formatTransactionDatesForCSV(transactions)).toBe('2026-01-01 | 2026-01-05 | 2026-01-10');
+  });
+});
+
+describe('formatTransactionAmountsForCSV', () => {
+  it('should return empty string for no transactions', () => {
+    expect(formatTransactionAmountsForCSV([])).toBe('');
+  });
+
+  it('should return the amount as a string for a single transaction', () => {
+    const transactions: Transaction[] = [{ date: '2026-04-17', amount: 14.93, currency: 'USD' }];
+    expect(formatTransactionAmountsForCSV(transactions)).toBe('14.93');
+  });
+
+  it('should join multiple amounts with " | "', () => {
+    const transactions: Transaction[] = [
+      { date: '2026-04-17', amount: 14.93, currency: 'USD' },
+      { date: '2026-04-20', amount: 61.01, currency: 'USD' },
+    ];
+    expect(formatTransactionAmountsForCSV(transactions)).toBe('14.93 | 61.01');
+  });
+
+  it('should handle integer amounts', () => {
+    const transactions: Transaction[] = [
+      { date: '2026-01-01', amount: 10, currency: 'EUR' },
+      { date: '2026-01-05', amount: 20, currency: 'EUR' },
+    ];
+    expect(formatTransactionAmountsForCSV(transactions)).toBe('10 | 20');
+  });
+
+  it('should handle three transactions', () => {
+    const transactions: Transaction[] = [
+      { date: '2026-01-01', amount: 10.0, currency: 'EUR' },
+      { date: '2026-01-05', amount: 20.5, currency: 'EUR' },
+      { date: '2026-01-10', amount: 5.99, currency: 'EUR' },
+    ];
+    expect(formatTransactionAmountsForCSV(transactions)).toBe('10 | 20.5 | 5.99');
+  });
+});
+
+describe('parseCPETransactionAmount', () => {
+  it('treats "-$X.XX" (Amazon debit) as positive charge in export', () => {
+    expect(parseCPETransactionAmount('-$51.12')).toEqual({ amount: 51.12, currency: 'USD' });
+  });
+
+  it('treats "$X.XX" (Amazon credit) as negative refund in export', () => {
+    expect(parseCPETransactionAmount('$10.00')).toEqual({ amount: -10, currency: 'USD' });
+  });
+
+  it('handles EUR amounts with European decimal comma', () => {
+    expect(parseCPETransactionAmount('-€52,95')).toEqual({ amount: 52.95, currency: 'EUR' });
+  });
+
+  it('handles the unicode minus sign (−) as a debit indicator', () => {
+    expect(parseCPETransactionAmount('−$51.12')).toEqual({ amount: 51.12, currency: 'USD' });
+  });
+
+  it('returns null for zero amounts', () => {
+    expect(parseCPETransactionAmount('$0.00')).toBeNull();
+  });
+
+  it('returns null when no price is found', () => {
+    expect(parseCPETransactionAmount('no amount here')).toBeNull();
+  });
+
+  it('trims whitespace before checking for the minus sign', () => {
+    expect(parseCPETransactionAmount('  -$14.93  ')).toEqual({ amount: 14.93, currency: 'USD' });
+  });
+});


### PR DESCRIPTION
Reopens @pmc2010's #23, rebased on current `main` with all review comments addressed.

## Review fixes vs #23
- Removed unused `extractSignedPriceFromText` + its tests
- Removed `CLAUDE.md`
- Dropped `jsdom` — CPE DOM traversal moved to `content.ts`, `transactionUtils` is pure and tested without a DOM env
- `transactionOrigin` derived **per-order** from `order.detailsUrl` (fixes mixed-locale exports)
- JSON export honors `includeTransactions` (matches CSV)
- `includeTransactions` destructured in `startExport`

## Notes
Rebased on top of the recipient-fields / stop-button / extra-locales work merged since #23. CSV has 18 base cols + 2 optional transaction cols.

## Test plan
- [x] typecheck / lint / prettier / **170 tests passing**
- [ ] Manual smoke test on amazon.de