### PR TITLE
feat: auto-download invoice PDFs during export

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Browser extension for exporting your Amazon order history to JSON or CSV format.
 - **Date Range Filtering** — Export orders within a specific date range
 - **Multiple Formats** — Export as JSON or CSV
 - **Cancellable Exports** — Stop an export while it is in progress
+- **Invoice PDF Download** — Optionally save the invoice PDF of each order to your Downloads folder
 - **Privacy Focused** — No tracking or data collection; all processing happens locally
 - **Open Source** — Free to use and modify
 
@@ -121,8 +122,9 @@ The built extensions will be in browser-specific directories:
 2. Navigate to Amazon and log in to your account
 3. Click the extension icon in the toolbar
 4. Select your export options (date range, format)
-5. Click "Export" to download your order history
-6. To cancel an export in progress, reopen the popup and click "Stop Export"
+5. Optionally check **Download invoice PDFs** to save each order's invoice PDF to `amazon-invoices/` in your Downloads folder (adds one extra page fetch per order, so exports take longer). Multi-shipment orders are suffixed `_1`, `_2`, ... to keep filenames unique. On Chrome the download shelf is temporarily hidden during the export so it isn't flooded; Firefox has no equivalent API and the panel behaves normally.
+6. Click "Export" to download your order history
+7. To cancel an export in progress, reopen the popup and click "Stop Export"
 
 ---
 

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -47,6 +47,14 @@
     "message": "Exportieren",
     "description": "Export button text"
   },
+  "downloadInvoices": {
+    "message": "Rechnungs-PDFs herunterladen",
+    "description": "Checkbox label to auto-download the invoice PDF of each order"
+  },
+  "downloadInvoicesHint": {
+    "message": "Speichert ein PDF pro Bestellung im Downloads-Ordner (langsamer)",
+    "description": "Hint text below the download invoices checkbox"
+  },
   "stopExport": {
     "message": "Export abbrechen",
     "description": "Stop button text"

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -47,6 +47,14 @@
     "message": "Export Orders",
     "description": "Export button text"
   },
+  "downloadInvoices": {
+    "message": "Download invoice PDFs",
+    "description": "Checkbox label to auto-download the invoice PDF of each order"
+  },
+  "downloadInvoicesHint": {
+    "message": "Saves one PDF per order to your Downloads folder (slower)",
+    "description": "Hint text below the download invoices checkbox"
+  },
   "stopExport": {
     "message": "Stop Export",
     "description": "Stop button text"

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -47,6 +47,14 @@
     "message": "Exportar pedidos",
     "description": "Export button text"
   },
+  "downloadInvoices": {
+    "message": "Descargar facturas en PDF",
+    "description": "Checkbox label to auto-download the invoice PDF of each order"
+  },
+  "downloadInvoicesHint": {
+    "message": "Guarda un PDF por pedido en tu carpeta de Descargas (más lento)",
+    "description": "Hint text below the download invoices checkbox"
+  },
   "stopExport": {
     "message": "Detener exportación",
     "description": "Stop button text"

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -47,6 +47,14 @@
     "message": "Exporter les commandes",
     "description": "Export button text"
   },
+  "downloadInvoices": {
+    "message": "Télécharger les factures PDF",
+    "description": "Checkbox label to auto-download the invoice PDF of each order"
+  },
+  "downloadInvoicesHint": {
+    "message": "Enregistre un PDF par commande dans votre dossier Téléchargements (plus lent)",
+    "description": "Hint text below the download invoices checkbox"
+  },
   "stopExport": {
     "message": "Arrêter l'exportation",
     "description": "Stop button text"

--- a/src/_locales/sv/messages.json
+++ b/src/_locales/sv/messages.json
@@ -47,6 +47,14 @@
     "message": "Exportera beställningar",
     "description": "Export button text"
   },
+  "downloadInvoices": {
+    "message": "Ladda ner fakturor som PDF",
+    "description": "Checkbox label to auto-download the invoice PDF of each order"
+  },
+  "downloadInvoicesHint": {
+    "message": "Sparar en PDF per beställning i din Nedladdningar-mapp (långsammare)",
+    "description": "Hint text below the download invoices checkbox"
+  },
   "stopExport": {
     "message": "Stoppa export",
     "description": "Stop button text"

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -4,7 +4,7 @@
  */
 
 import browser from 'webextension-polyfill';
-import type { DownloadData, MessagePayload } from '../types';
+import type { DownloadData, DownloadUrlData, MessagePayload } from '../types';
 
 /**
  * Get localized message from browser i18n API
@@ -20,6 +20,19 @@ browser.runtime.onMessage.addListener((message: any, _sender: any) => {
 
   if (msg.action === 'downloadFile') {
     return downloadFile(msg.data as DownloadData)
+      .then(() => ({ success: true }))
+      .catch((error: Error) => ({ success: false, error: error.message }));
+  }
+
+  if (msg.action === 'downloadInvoiceUrl') {
+    return downloadInvoiceUrl(msg.data as DownloadUrlData)
+      .then(() => ({ success: true }))
+      .catch((error: Error) => ({ success: false, error: error.message }));
+  }
+
+  if (msg.action === 'setDownloadsUIEnabled') {
+    const enabled = Boolean((msg.data as { enabled?: boolean } | undefined)?.enabled);
+    return setDownloadsUIEnabled(enabled)
       .then(() => ({ success: true }))
       .catch((error: Error) => ({ success: false, error: error.message }));
   }
@@ -77,6 +90,36 @@ async function downloadFile(data: DownloadData): Promise<number> {
     }
     throw error;
   }
+}
+
+/**
+ * Download an invoice PDF from an Amazon URL, letting the browser reuse
+ * the user's session cookies for authentication. Silent (no Save-As
+ * prompt) since one export can queue dozens of invoices; conflicts are
+ * uniquified so re-runs of the same order don't overwrite prior files.
+ */
+async function downloadInvoiceUrl(data: DownloadUrlData): Promise<number> {
+  return browser.downloads.download({
+    url: data.url,
+    filename: data.fileName,
+    saveAs: false,
+    conflictAction: 'uniquify',
+  });
+}
+
+/**
+ * Toggle Chrome's download shelf/bubble so a bulk invoice export doesn't
+ * spam the UI. Requires the `downloads.ui` permission (Chrome only).
+ * Firefox lacks this API, so we silently no-op. The setting is per-session
+ * and MUST be re-enabled once the export is done, otherwise later manual
+ * downloads by the user would stay invisible.
+ */
+async function setDownloadsUIEnabled(enabled: boolean): Promise<void> {
+  const api = browser.downloads as typeof browser.downloads & {
+    setUiOptions?: (options: { enabled: boolean }) => Promise<void>;
+  };
+  if (typeof api.setUiOptions !== 'function') return;
+  await api.setUiOptions({ enabled });
 }
 
 // Log when extension is installed or updated

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,3 +7,10 @@ export const STORAGE_KEY = 'amazonExporter';
 
 /** Key for the stop-requested flag in browser.storage.session */
 export const STOP_FLAG_KEY = 'amazonExporterStopRequested';
+
+/**
+ * Subfolder (relative to the browser's Downloads directory) that
+ * receives auto-downloaded invoice PDFs. Kept separate from the JSON/CSV
+ * export so the user's Downloads root stays uncluttered.
+ */
+export const INVOICE_DOWNLOAD_SUBFOLDER = 'amazon-invoices';

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -20,8 +20,11 @@ import {
   parsePrice,
   CURRENCY_TOKEN,
   parseOrderStatus,
+  buildInvoicePopoverUrl,
+  isPdfInvoiceHref,
+  buildInvoiceFilename,
 } from '../utils';
-import { STORAGE_KEY, STOP_FLAG_KEY } from '../constants';
+import { STORAGE_KEY, STOP_FLAG_KEY, INVOICE_DOWNLOAD_SUBFOLDER } from '../constants';
 
 (function (): void {
   'use strict';
@@ -81,7 +84,13 @@ import { STORAGE_KEY, STOP_FLAG_KEY } from '../constants';
   function getExportState(): ExportState | null {
     try {
       const data = sessionStorage.getItem(STORAGE_KEY);
-      return data ? (JSON.parse(data) as ExportState) : null;
+      if (!data) return null;
+      const state = JSON.parse(data) as ExportState;
+      // Backward-compat default: older sessions may lack this field.
+      if (typeof state.downloadInvoices !== 'boolean') {
+        state.downloadInvoices = false;
+      }
+      return state;
     } catch {
       return null;
     }
@@ -145,7 +154,7 @@ import { STORAGE_KEY, STOP_FLAG_KEY } from '../constants';
     // Reset stop flag for fresh export
     stopRequested = false;
 
-    const { format, startDate, endDate, exportAll } = options;
+    const { format, startDate, endDate, exportAll, downloadInvoices } = options;
 
     // Get available years
     const years = getAvailableYears();
@@ -170,6 +179,7 @@ import { STORAGE_KEY, STOP_FLAG_KEY } from '../constants';
       startDate: startDate,
       endDate: endDate,
       exportAll: exportAll,
+      downloadInvoices: downloadInvoices,
       yearsToProcess: yearsToProcess,
       currentYearIndex: 0,
       currentStartIndex: 0,
@@ -293,8 +303,19 @@ import { STORAGE_KEY, STOP_FLAG_KEY } from '../constants';
 
     updateProgress(80, getMessage('fetchingPrices', [String(state.collectedOrders.length)]));
 
-    // Fetch item prices for multi-item orders
-    await fetchOrderDetailsForPrices(state.collectedOrders);
+    // `finally` guarantees the shelf is restored even on stop or throw.
+    // Otherwise Chrome would keep hiding the user's later manual downloads.
+    if (state.downloadInvoices) {
+      await setDownloadsUIEnabled(false);
+    }
+    try {
+      // Fetch item prices for multi-item orders (and optionally invoice PDFs)
+      await fetchOrderDetailsForPrices(state.collectedOrders, state.downloadInvoices);
+    } finally {
+      if (state.downloadInvoices) {
+        await setDownloadsUIEnabled(true);
+      }
+    }
 
     // Check if stop was requested during price fetching (state already cleared by handler)
     if (stopRequested || !getExportState()) {
@@ -837,7 +858,10 @@ import { STORAGE_KEY, STOP_FLAG_KEY } from '../constants';
   /**
    * Fetch order details for item prices and discounts
    */
-  async function fetchOrderDetailsForPrices(orders: Order[]): Promise<void> {
+  async function fetchOrderDetailsForPrices(
+    orders: Order[],
+    downloadInvoices: boolean
+  ): Promise<void> {
     // We need to fetch details for all orders to get accurate pricing and discounts
     // Even single-item orders can have discounts
     const ordersNeedingDetails = orders.filter((order) => order.detailsUrl);
@@ -872,11 +896,103 @@ import { STORAGE_KEY, STOP_FLAG_KEY } from '../constants';
         parseItemPricesFromDetails(order, doc);
         parsePromotionsFromDetails(order, doc);
 
+        // The order-details page only holds an AJAX trigger. The real
+        // PDF link lives in the invoice popover, so we fetch that too.
+        if (downloadInvoices && order.orderId) {
+          let orderOrigin = '';
+          try {
+            orderOrigin = new URL(order.detailsUrl).origin;
+          } catch {
+            console.warn(
+              '[Amazon Exporter] Could not derive origin from detailsUrl for order:',
+              order.orderId
+            );
+          }
+          if (orderOrigin) {
+            await new Promise((resolve) => setTimeout(resolve, 200));
+            try {
+              await downloadInvoicePdfsForOrder(order.orderId, orderOrigin);
+            } catch (invoiceError) {
+              console.warn(
+                '[Amazon Exporter] Error downloading invoices for order:',
+                order.orderId,
+                invoiceError
+              );
+            }
+          }
+        }
+
         await new Promise((resolve) => setTimeout(resolve, 200));
       } catch (error) {
         console.warn('[Amazon Exporter] Error fetching details:', error);
       }
     }
+  }
+
+  /**
+   * Runs best-effort: a failure on one order doesn't abort the export.
+   */
+  async function downloadInvoicePdfsForOrder(orderId: string, origin: string): Promise<void> {
+    const popoverUrl = buildInvoicePopoverUrl(origin, orderId);
+    const response = await fetch(popoverUrl, { credentials: 'include' });
+    if (!response.ok) {
+      console.warn(
+        `[Amazon Exporter] Invoice popover fetch failed for ${orderId}: HTTP ${response.status}`
+      );
+      return;
+    }
+    const doc = new DOMParser().parseFromString(await response.text(), 'text/html');
+    const hrefs = extractInvoicePdfHrefs(doc);
+    if (hrefs.length === 0) {
+      console.warn(`[Amazon Exporter] No PDF invoice link found in popover for ${orderId}`);
+      return;
+    }
+    for (let i = 0; i < hrefs.length; i++) {
+      const href = hrefs[i];
+      if (!href) continue;
+      const url = new URL(href, origin).toString();
+      const fileName = buildInvoiceFilename(orderId, i, hrefs.length, INVOICE_DOWNLOAD_SUBFOLDER);
+      try {
+        await browser.runtime.sendMessage({
+          action: 'downloadInvoiceUrl',
+          data: { url, fileName },
+        });
+      } catch (msgError) {
+        console.warn(
+          '[Amazon Exporter] Failed to dispatch invoice download for order:',
+          orderId,
+          msgError
+        );
+      }
+    }
+  }
+
+  /**
+   * Ask the background page to show or hide Chrome's download shelf.
+   * Best-effort: failures are logged, not surfaced to the user, since a
+   * cosmetic UI toggle should never abort the export itself.
+   */
+  async function setDownloadsUIEnabled(enabled: boolean): Promise<void> {
+    try {
+      await browser.runtime.sendMessage({
+        action: 'setDownloadsUIEnabled',
+        data: { enabled },
+      });
+    } catch (error) {
+      console.warn('[Amazon Exporter] Failed to toggle downloads UI:', error);
+    }
+  }
+
+  function extractInvoicePdfHrefs(doc: Document): string[] {
+    // Prefer `.invoice-list` (present in every popover sample) but fall
+    // back to the whole doc so a markup tweak doesn't silently break us.
+    const scope: ParentNode = doc.querySelector('.invoice-list') ?? doc;
+    const hrefs: string[] = [];
+    for (const a of scope.querySelectorAll('a[href]')) {
+      const href = a.getAttribute('href') || '';
+      if (isPdfInvoiceHref(href)) hrefs.push(href);
+    }
+    return hrefs;
   }
 
   /**

--- a/src/manifest.chrome.json
+++ b/src/manifest.chrome.json
@@ -9,7 +9,7 @@
     "96": "icons/icon-96.png",
     "128": "icons/icon-128.png"
   },
-  "permissions": ["activeTab", "downloads", "storage"],
+  "permissions": ["activeTab", "downloads", "downloads.ui", "storage"],
   "host_permissions": [
     "*://*.amazon.com/*",
     "*://*.amazon.co.uk/*",

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -245,3 +245,37 @@ footer a:hover {
 #settings-section {
   transition: opacity 0.2s ease;
 }
+
+.checkbox-label {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  cursor: pointer;
+  padding: 10px 12px;
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  transition: all 0.2s ease;
+}
+
+.checkbox-label:hover {
+  border-color: #ff9900;
+  background: #fff8e5;
+}
+
+.checkbox-label input[type='checkbox'] {
+  margin-top: 2px;
+  accent-color: #ff9900;
+  flex-shrink: 0;
+}
+
+.checkbox-content {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.hint {
+  font-size: 11px;
+  color: #888;
+}

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -66,6 +66,18 @@
               </label>
             </div>
           </section>
+
+          <section class="section">
+            <label class="checkbox-label">
+              <input type="checkbox" id="downloadInvoices" />
+              <div class="checkbox-content">
+                <span data-i18n="downloadInvoices">Download invoice PDFs</span>
+                <span class="hint" data-i18n="downloadInvoicesHint"
+                  >Saves one PDF per order to your Downloads folder (slower)</span
+                >
+              </div>
+            </label>
+          </section>
         </div>
 
         <section class="section">

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -45,6 +45,15 @@ document.addEventListener('DOMContentLoaded', async () => {
   const startDateInput = document.getElementById('startDate') as HTMLInputElement;
   const endDateInput = document.getElementById('endDate') as HTMLInputElement;
   const settingsSection = document.getElementById('settings-section') as HTMLElement;
+  const downloadInvoicesCheckbox = document.getElementById('downloadInvoices') as HTMLInputElement;
+
+  // Restore persisted checkbox state
+  const stored = await browser.storage.local.get('downloadInvoices');
+  downloadInvoicesCheckbox.checked = stored['downloadInvoices'] === true;
+
+  downloadInvoicesCheckbox.addEventListener('change', () => {
+    void browser.storage.local.set({ downloadInvoices: downloadInvoicesCheckbox.checked });
+  });
 
   // Set default date values
   const today = new Date();
@@ -124,6 +133,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         startDate: startDate,
         endDate: endDate,
         exportAll: exportRange === 'all',
+        downloadInvoices: downloadInvoicesCheckbox.checked,
       };
 
       // Send message to content script

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -37,6 +37,7 @@ export interface ExportOptions {
   startDate: string | null;
   endDate: string | null;
   exportAll: boolean;
+  downloadInvoices: boolean;
 }
 
 export interface ExportState {
@@ -45,6 +46,7 @@ export interface ExportState {
   startDate: string | null;
   endDate: string | null;
   exportAll: boolean;
+  downloadInvoices: boolean;
   yearsToProcess: string[];
   currentYearIndex: number;
   currentStartIndex: number;
@@ -57,6 +59,11 @@ export interface DownloadData {
   content: string;
   fileName: string;
   mimeType: string;
+}
+
+export interface DownloadUrlData {
+  url: string;
+  fileName: string;
 }
 
 export interface MessagePayload {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -8,3 +8,4 @@ export * from './orderUtils';
 export * from './statusUtils';
 export * from './csvUtils';
 export * from './urlUtils';
+export * from './invoiceUtils';

--- a/src/utils/invoiceUtils.ts
+++ b/src/utils/invoiceUtils.ts
@@ -1,0 +1,60 @@
+/**
+ * Invoice URL building and pure link-classification utilities.
+ *
+ * DOM traversal for the invoice popover page lives in the content script
+ * (see `extractInvoicePdfHrefs` in content.ts). Helpers here are pure so
+ * they can be unit-tested without a DOM implementation.
+ */
+
+/**
+ * Build the URL of the "Invoice" popover that Amazon opens on click.
+ * The popover HTML is the only place the real PDF link lives; the
+ * order-details page only holds an AJAX trigger URL. We omit
+ * `relatedRequestId` (a page-scoped token) since Amazon still serves
+ * the popover without it as long as the session cookies are valid.
+ */
+export function buildInvoicePopoverUrl(origin: string, orderId: string): string {
+  return `${origin}/your-orders/invoice/popover?orderId=${encodeURIComponent(
+    orderId
+  )}&ref_=fed_invoice_ajax`;
+}
+
+/**
+ * Decide whether an `<a href>` from the invoice popover points at a
+ * downloadable PDF. The popover typically lists three links:
+ *   1. `/gp/css/summary/print.html?orderID=...` (HTML order summary)
+ *   2. `/documents/download/<uuid>/invoice.pdf` (the actual invoice PDF)
+ *   3. `/gp/help/contact/...` ("request an invoice" fallback)
+ * We keep only the second one, or any other `.pdf`-looking link, since
+ * third-party sellers may use different paths.
+ */
+export function isPdfInvoiceHref(href: string): boolean {
+  if (!href) return false;
+  const normalized = href.trim().toLowerCase();
+  if (normalized.startsWith('javascript:')) return false;
+  if (normalized.includes('/gp/help/')) return false;
+  if (normalized.includes('/summary/print.html')) return false;
+  if (normalized.includes('/summary/print.htm')) return false;
+  return /\.pdf(?:$|[?#])/i.test(normalized) || normalized.includes('/documents/download/');
+}
+
+/**
+ * Build the on-disk filename for a downloaded invoice PDF. The order ID
+ * appears verbatim so downstream tools can match files back to orders.
+ * When one order yields several invoices (multi-shipment orders), a
+ * 1-based index keeps filenames unique.
+ *
+ * The `subfolder` prefix (e.g. `"amazon-invoices"`) is relative to the
+ * browser's Downloads directory and lets the user keep invoices grouped
+ * without touching the browser's download settings.
+ */
+export function buildInvoiceFilename(
+  orderId: string,
+  index: number,
+  total: number,
+  subfolder?: string
+): string {
+  const suffix = total > 1 ? `_${index + 1}` : '';
+  const base = `${orderId}${suffix}.pdf`;
+  return subfolder ? `${subfolder}/${base}` : base;
+}

--- a/tests/invoiceUtils.test.ts
+++ b/tests/invoiceUtils.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildInvoicePopoverUrl,
+  isPdfInvoiceHref,
+  buildInvoiceFilename,
+} from '../src/utils/invoiceUtils';
+
+describe('buildInvoicePopoverUrl', () => {
+  it('builds the correct URL for amazon.fr', () => {
+    expect(buildInvoicePopoverUrl('https://www.amazon.fr', '407-0100142-8760371')).toBe(
+      'https://www.amazon.fr/your-orders/invoice/popover?orderId=407-0100142-8760371&ref_=fed_invoice_ajax'
+    );
+  });
+
+  it('uses the provided origin verbatim (no locale assumptions)', () => {
+    expect(buildInvoicePopoverUrl('https://www.amazon.de', '123-4567890-1234567')).toBe(
+      'https://www.amazon.de/your-orders/invoice/popover?orderId=123-4567890-1234567&ref_=fed_invoice_ajax'
+    );
+  });
+
+  it('URL-encodes the order ID', () => {
+    const url = buildInvoicePopoverUrl('https://www.amazon.com', 'x?y&z');
+    expect(url).toContain('orderId=x%3Fy%26z');
+  });
+});
+
+describe('isPdfInvoiceHref', () => {
+  it('accepts the /documents/download/<uuid>/invoice.pdf pattern (Amazon direct)', () => {
+    expect(
+      isPdfInvoiceHref('/documents/download/83f29a5a-8a6b-4e33-912f-faca564f0155/invoice.pdf')
+    ).toBe(true);
+  });
+
+  it('accepts any .pdf link (third-party sellers)', () => {
+    expect(isPdfInvoiceHref('/invoice/Invoice-10311208054609.pdf')).toBe(true);
+    expect(isPdfInvoiceHref('/invoice/download?file=invoiceId-2509869886.pdf')).toBe(true);
+  });
+
+  it('rejects the printable order summary link', () => {
+    expect(isPdfInvoiceHref('/gp/css/summary/print.html?orderID=407-0100142-8760371')).toBe(false);
+  });
+
+  it('rejects the "request an invoice" contact link', () => {
+    expect(isPdfInvoiceHref('/gp/help/contact/contact.html?orderID=407-0100142-8760371')).toBe(
+      false
+    );
+  });
+
+  it('rejects javascript: pseudo-URLs', () => {
+    expect(isPdfInvoiceHref('javascript:void(0)')).toBe(false);
+  });
+
+  it('rejects empty strings', () => {
+    expect(isPdfInvoiceHref('')).toBe(false);
+  });
+
+  it('is case-insensitive on the extension', () => {
+    expect(isPdfInvoiceHref('/documents/download/x/INVOICE.PDF')).toBe(true);
+  });
+});
+
+describe('buildInvoiceFilename', () => {
+  it('returns the plain order-id filename when there is only one invoice', () => {
+    expect(buildInvoiceFilename('407-0100142-8760371', 0, 1)).toBe('407-0100142-8760371.pdf');
+  });
+
+  it('suffixes with a 1-based index when the order has several invoices', () => {
+    expect(buildInvoiceFilename('407-0100142-8760371', 0, 3)).toBe('407-0100142-8760371_1.pdf');
+    expect(buildInvoiceFilename('407-0100142-8760371', 1, 3)).toBe('407-0100142-8760371_2.pdf');
+    expect(buildInvoiceFilename('407-0100142-8760371', 2, 3)).toBe('407-0100142-8760371_3.pdf');
+  });
+
+  it('prepends the subfolder when provided', () => {
+    expect(buildInvoiceFilename('407-0100142-8760371', 0, 1, 'amazon-invoices')).toBe(
+      'amazon-invoices/407-0100142-8760371.pdf'
+    );
+  });
+
+  it('keeps the subfolder in the multi-invoice case too', () => {
+    expect(buildInvoiceFilename('407-0100142-8760371', 1, 2, 'amazon-invoices')).toBe(
+      'amazon-invoices/407-0100142-8760371_2.pdf'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds an opt-in "Download invoice PDFs" checkbox to the popup. When enabled, each order's invoice popover (`/your-orders/invoice/popover?orderId=...`) is fetched and every PDF link it contains is dispatched to the background page for download. Files land in `amazon-invoices/<orderId>.pdf` under the browser's Downloads directory, suffixed `_1` / `_2` / ... when a single order yields several invoices.

Chrome's download shelf/bubble is silenced for the duration of the invoice loop via `browser.downloads.setUiOptions({enabled: false})` and restored in a `finally` so a stop-request or a fetch error can't leave the UI stuck. This requires the new `downloads.ui` permission (Chrome only). Firefox lacks the API and silently no-ops.

- New pure module `src/utils/invoiceUtils.ts` with URL builder, PDF-link classifier, filename builder
- New `INVOICE_DOWNLOAD_SUBFOLDER` constant in `src/constants.ts`
- `ExportOptions` / `ExportState` gain a `downloadInvoices` boolean, with backward-compat default in `getExportState`
- i18n strings added to en / fr / de / es / sv
- 27 new unit tests


## Maintainer Collaboration

- [x] I enabled **Allow edits from maintainers** on this PR.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Chore/maintenance

## Breaking Changes

- [ ] This PR introduces a breaking change.
- [ ] I documented migration or compatibility notes (if applicable).

## UI Changes

- [x] This PR includes UI changes.
- [x] I added screenshots or recordings for UI changes (if applicable).

<img width="318" height="475" alt="image" src="https://github.com/user-attachments/assets/e306fd7c-804e-44ee-b136-b50c9b9c858e" />

New checkbox "Download invoice PDFs" appears in the popup below the format radio group. When unchecked (default), no behavior change.

## How Was This Tested?

```bash
npm run lint
npm run typecheck
npm run test        # 228 passing (201 pre-existing + 27 new invoiceUtils tests)
npm run format:check
npm run knip        # no new unused exports
npm run build       # Firefox + Chrome
```

Manual smoke tests on **amazon.fr** and **amazon.com** with 2+ orders each: invoice PDFs downloaded correctly to `~/Downloads/amazon-invoices/`, download shelf stayed hidden during the invoice loop and returned in time for the final JSON download. The popover URL (`/your-orders/invoice/popover?orderId=...`) and the PDF-link classifier are locale-agnostic, so other Amazon marketplaces (de / co.uk / it / es / ...) should behave the same.

## Checklist

- [x] I verified the change locally.
- [x] I added or updated tests when behavior changed.
- [x] I updated documentation when needed.
- [x] I updated locale/messages or metadata when needed.
- [x] I confirmed no sensitive data was added.